### PR TITLE
Add ACPU table add/remove/modify functionality

### DIFF
--- a/src/components/ModalWindows/ModalWindow.js
+++ b/src/components/ModalWindows/ModalWindow.js
@@ -62,7 +62,7 @@ const ModalWindow = (props) => {
                 <input
                     type="number"
                     step={item.step ? item.step : 1}
-                    onChange={(e) => item.handleChange(item.id, e.target.value / 100)}
+                    onChange={(e) => handleChange(item.id, e.target.value / 100)}
                     value={(formState[item.id] * 100).toFixed(item.step ? (item.step >= 1 ? 0 : 1) : 1)}
                 />
             </div>

--- a/src/components/Tables/ACPUTable.js
+++ b/src/components/Tables/ACPUTable.js
@@ -3,9 +3,9 @@ import PowerTable from "./PowerTable";
 import { FaPlus } from "react-icons/fa6";
 import * as server from "../../utils/serverAPI"
 import { acpu_name, load_activity } from "./../../utils/acpu"
-import { TableBase } from "./TableBase";
+import { TableBase, Actions } from "./TableBase";
 import ACPUModal from "../ModalWindows/ACPUModal";
-import { PowerCell, SelectionCell, PercentsCell, Actions } from "./TableCells"
+import { PowerCell, SelectionCell, PercentsCell } from "./TableCells"
 import { GetText } from "../../utils/common";
 
 import "./../style/ACPUTable.css"
@@ -14,25 +14,15 @@ function ACPUTable({ device, onDataChanged }) {
     const [editIndex, setEditIndex] = React.useState(null);
     const [modalOpen, setModalOpen] = React.useState(false);
     const [powerData, setPowerData] = React.useState([])
-    const [acpuData, setAcpuData] = React.useState({})
-    const [acpuUserData, setAcpuUserData] = React.useState({
+    const [acpuData, setAcpuData] = React.useState({
         name: '',
         frequency: 0,
         load: 0
     })
-    const [endpoint, setEndpoint] = React.useState({
-        "name": "",
-        "activity": 0,
-        "read_write_rate": 0.5,
-        "toggle_rate": 0.125,
-        "consumption": {
-            "calculated_bandwidth": 0,
-            "noc_power": 0,
-            "message": ""
-        }
-    })
     const [endpoints, setEndpoints] = React.useState([])
+    const [endpointsToDisplay, setEndpointsToDisplay] = React.useState([])
     const [href, setHref] = React.useState('')
+    const [addButtonDisable, setAddButtonDisable] = React.useState(true)
 
     function fetchData(device) {
         setPowerData([
@@ -51,25 +41,27 @@ function ACPUTable({ device, onDataChanged }) {
         }
     }, [device])
 
+    React.useEffect(() => {
+        endpoints.sort((a, b) => a.ep - b.ep)
+        setEndpointsToDisplay(endpoints)
+    }, [endpoints])
+
     function fetchPort(port) {
-        // TODO
-        // server.GET(server.peripheralPath(device, href + '/' + port.href), (data) => {
-        //     console.log(endpoints)
-        //     if (data.name !== '') {
-        //         setEndpoints([...endpoints, data])
-        //     }
-        // })
+        server.GET(server.peripheralPath(device, href + '/' + port.href), (data) => {
+            if (data.name !== '') {
+                setEndpoints(prevVal => [...prevVal, { ep: port.href.slice(-1), data: data }])
+            }
+        })
     }
 
     function fetchAcpuData() {
         if (href !== '') {
             server.GET(server.peripheralPath(device, href), (data) => {
-                setAcpuData(data)
                 // resolve cycling
-                if (data.name !== acpuUserData.name ||
-                    data.frequency !== acpuUserData.frequency ||
-                    data.load !== acpuUserData.load) {
-                    setAcpuUserData({
+                if (data.name !== acpuData.name ||
+                    data.frequency !== acpuData.frequency ||
+                    data.load !== acpuData.load) {
+                    setAcpuData({
                         name: data.name,
                         frequency: data.frequency,
                         load: data.load
@@ -90,34 +82,52 @@ function ACPUTable({ device, onDataChanged }) {
     }, [href])
 
     React.useEffect(() => {
+        setAddButtonDisable(endpoints.length >= 4)
+    }, [endpoints])
+
+    React.useEffect(() => {
         if (device !== null && href !== '') {
-            server.PATCH(server.peripheralPath(device, href), acpuUserData, fetchAcpuData)
+            server.PATCH(server.peripheralPath(device, href), acpuData, fetchAcpuData)
         }
-    }, [acpuUserData])
+    }, [acpuData])
 
     const handleChange = (name, val) => {
-        setAcpuUserData({ ...acpuUserData, [name]: val })
+        setAcpuData({ ...acpuData, [name]: val })
         onDataChanged()
     };
-
-    function fetchTable() {
-        //
-    }
 
     const header = ['Endpoint', 'Activity', 'R/W', 'Toggle Rate', 'Bandwidth', 'Noc Power', 'Action']
 
     function modifyRow(index, row) {
+        var data = row;
+        data.name = GetText(row.name, acpu_name)
+        server.PATCH(server.peripheralPath(device, href + '/ep/' + endpoints[index].ep), data, fetchAcpuData)
     }
 
     const deleteRow = (index) => {
+        // no delete method for acpu. this is just clear name of the endpoint which mean disable
+        let val = endpoints[index].data
+        val.name = ''
+        server.PATCH(server.peripheralPath(device, href + '/ep/' + endpoints[index].ep), val, fetchAcpuData)
+        onDataChanged()
+    }
+
+    function findEvailableIndex() {
+        let index = 0
+        for (let ep of endpoints) {
+            if (index < ep.ep)
+                return index
+            else
+                index = index + 1
+        }
+        return index
     }
 
     function addRow(newData) {
         if (device !== null) {
             var data = newData;
             data.name = GetText(newData.name, acpu_name)
-            // TODO
-            // server.PATCH(server.peripheralPath(device, href + '/ep/0'), data, fetchAcpuData)
+            server.PATCH(server.peripheralPath(device, href + '/ep/' + findEvailableIndex()), data, fetchAcpuData)
         }
     }
 
@@ -126,68 +136,76 @@ function ACPUTable({ device, onDataChanged }) {
             modifyRow(editIndex, newRow);
         else
             addRow(newRow);
+        onDataChanged()
     };
 
     const powerHeader = ['Power', '%']
     return <div className="acpu-container">
-        <div>
-            <div className="acpu-group">
-                <label>ACPU name</label>
-                <input type={'text'} onChange={(e) => handleChange('name', e.target.value)} value={acpuUserData.name}></input>
-            </div>
-            <div className="acpu-group">
-                <label>Frequency</label>
-                <input type={'number'} step={1} onChange={(e) => handleChange('frequency', e.target.value)} value={acpuUserData.frequency}></input>
-            </div>
-            <div className="acpu-group">
-                <label>Load</label>
-                <select type={'text'} value={acpuUserData.load} onChange={(e) => handleChange('load', parseInt(e.target.value))}>
-                    {
-                        load_activity.map((it) => (
-                            <option key={it.id} value={it.id}>{it.text}</option>
-                        ))
-                    }
-                </select>
-            </div>
-        </div>
         <div className="main-block">
             <div className="layout-head">
                 <label>FPGA &gt; ACPU</label>
-                <button className="plus-button" onClick={() => setModalOpen(true)}><FaPlus /></button>
+                <button disabled={addButtonDisable} className="plus-button" onClick={() => setModalOpen(true)}><FaPlus /></button>
             </div>
-            <TableBase
-                header={header}
-                data={
-                    endpoints.map((row, index) => {
-                        return <tr key={index}>
-                            <td>{row.name}</td>
-                            <SelectionCell val={row.activity} values={load_activity} />
-                            <PercentsCell val={row.read_write_rate} />
-                            <PercentsCell val={row.toggle_rate} precition={1} />
-                            <PowerCell val={row.consumption.calculated_bandwidth} />
-                            <PowerCell val={row.consumption.noc_power} />
-                            <Actions
-                                onEditClick={() => { setEditIndex(index); setModalOpen(true) }}
-                                onDeleteClick={() => deleteRow(index)}
-                            />
-                        </tr>
-                    })
-                }
-            />
-            {modalOpen &&
-                <ACPUModal
-                    closeModal={() => {
-                        setModalOpen(false);
-                        setEditIndex(null);
-                    }}
-                    onSubmit={handleSubmit}
-                    defaultValue={editIndex !== null && endpoint || {
-                        "name": 0,
-                        "activity": 0,
-                        "read_write_rate": 0.5,
-                        "toggle_rate": 0.125,
-                    }}
-                />}
+            <div className="cpu-container">
+                <div className="acpu-group-container">
+                    <div className="acpu-group">
+                        <label>ACPU name</label>
+                        <input type={'text'} onChange={(e) => handleChange('name', e.target.value)} value={acpuData.name}></input>
+                    </div>
+                    <div className="acpu-group">
+                        <label>Frequency</label>
+                        <input type={'number'} step={1} onChange={(e) => handleChange('frequency', e.target.value)} value={acpuData.frequency}></input>
+                    </div>
+                    <div className="acpu-group">
+                        <label>Load</label>
+                        <select type={'text'} value={acpuData.load} onChange={(e) => handleChange('load', parseInt(e.target.value))}>
+                            {
+                                load_activity.map((it) => (
+                                    <option key={it.id} value={it.id}>{it.text}</option>
+                                ))
+                            }
+                        </select>
+                    </div>
+                </div>
+                <TableBase
+                    header={header}
+                    data={
+                        endpointsToDisplay.map((row, index) => {
+                            return <tr key={index}>
+                                <td>{row.data.name}</td>
+                                <SelectionCell val={row.data.activity} values={load_activity} />
+                                <PercentsCell val={row.data.read_write_rate} />
+                                <PercentsCell val={row.data.toggle_rate} precition={1} />
+                                <PowerCell val={row.data.consumption.calculated_bandwidth} />
+                                <PowerCell val={row.data.consumption.noc_power} />
+                                <Actions
+                                    onEditClick={() => { setEditIndex(index); setModalOpen(true) }}
+                                    onDeleteClick={() => deleteRow(index)}
+                                />
+                            </tr>
+                        })
+                    }
+                />
+                {modalOpen &&
+                    <ACPUModal
+                        closeModal={() => {
+                            setModalOpen(false);
+                            setEditIndex(null);
+                        }}
+                        onSubmit={handleSubmit}
+                        defaultValue={editIndex !== null && {
+                            "name": acpu_name.indexOf(acpu_name.find(elem => elem.text == endpoints[editIndex].data.name)),
+                            "activity": endpoints[editIndex].data.activity,
+                            "read_write_rate": endpoints[editIndex].data.read_write_rate,
+                            "toggle_rate": endpoints[editIndex].data.toggle_rate,
+                        } || {
+                            "name": 0,
+                            "activity": 0,
+                            "read_write_rate": 0.5,
+                            "toggle_rate": 0.125,
+                        }}
+                    />}
+            </div>
         </div>
         <PowerTable title={'ACPU power'}
             total={0}

--- a/src/components/style/ACPUTable.css
+++ b/src/components/style/ACPUTable.css
@@ -21,3 +21,14 @@
     padding: 0.2rem;
     font-size: 1rem;
 }
+
+.cpu-container {
+    padding: 10px;
+    display: inline-flex;
+    gap: 10px;
+}
+
+.acpu-group-container {
+    border-right: 1px solid #e3e3e3;
+    padding-right: 10px;
+}

--- a/src/components/style/PowerTable.css
+++ b/src/components/style/PowerTable.css
@@ -3,6 +3,7 @@
     padding: 0.4rem;
     border-radius: 10px;
     max-width: min-content;
+    height: fit-content;
 }
 
 .total-table {


### PR DESCRIPTION
Updates:
1. Add ACPU table add/modify/delete functionality
2. Update ACPU table components view
3. Fixed issue with Toggle Rate fields in different tables when user try to modify it.


![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/a991f239-7493-43ce-9af9-05bfc9c320d9)

Open issue:
* Need to work on rows order in ACPU table. As for now, it is always ordered by port number.
* Reflect endpoints power on the main block (green one)
