### PR TITLE
Add preferences menu, add components selection

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,8 +1,28 @@
-const { app, BrowserWindow, Menu } = require('electron');
+const {
+  app, BrowserWindow, Menu, ipcMain,
+} = require('electron');
 const { spawn } = require('child_process');
 const path = require('node:path');
 const fs = require('fs');
+const Store = require('electron-store');
 const config = require('./rpe.config.json');
+
+const schema = {
+  port: {
+    type: 'number',
+    maximum: 65535,
+    minimum: 1,
+    default: config.port,
+  },
+  device_xml: {
+    type: 'string',
+    default: config.device_xml,
+  },
+};
+
+const store = new Store({ schema });
+
+let mainWindow = null;
 
 const isDev = process.argv.find((val) => val === '--development');
 const template = [
@@ -16,7 +36,12 @@ const template = [
       { label: 'Save' },
       { label: 'Save as...' },
       { type: 'separator' },
-      { label: 'Preferences' },
+      {
+        label: 'Preferences',
+        click: async () => {
+          mainWindow.webContents.send('preferences', store.store);
+        },
+      },
       { type: 'separator' },
       { role: 'quit' },
     ],
@@ -50,24 +75,21 @@ const template = [
   },
 ];
 
-const menu = Menu.buildFromTemplate(template);
-Menu.setApplicationMenu(menu);
-
 const startFlaskServer = () => {
-  console.log(isDev);
   let apiServer;
   const RestAPIscript = path.join(__dirname, 'backend/restapi_server.py');
   const restAPIexe = path.join(app.getAppPath(), '..', '..', 'backend', 'restapi_server.exe');
 
   const args = [
-    '--port', config.port,
+    '--port', store.get('port'),
   ];
   if (config.debug === 1) { args.push('--debug'); }
 
+  const deviceXml = store.get('device_xml');
   if (fs.existsSync(RestAPIscript)) {
-    apiServer = spawn('python', [RestAPIscript, path.join(__dirname, config.device_xml), ...args]);
+    apiServer = spawn('python', [RestAPIscript, path.join(__dirname, deviceXml), ...args]);
   } else {
-    apiServer = spawn(restAPIexe, [path.join(app.getAppPath(), '..', '..', config.device_xml), ...args]);
+    apiServer = spawn(restAPIexe, [path.join(app.getAppPath(), '..', '..', deviceXml), ...args]);
   }
 
   apiServer.stdout.on('data', (data) => {
@@ -93,13 +115,28 @@ const startFlaskServer = () => {
   return apiServer;
 };
 
-const createWindow = () => {
-  const win = new BrowserWindow({ width: 1100, height: 700 });
-  const indexPath = path.join(app.getAppPath(), 'build/index.html');
-  win.loadURL(`file://${indexPath}`);
-};
-
 let child = null;
+const createWindow = () => {
+  mainWindow = new BrowserWindow({
+    width: 1100,
+    height: 700,
+    webPreferences: {
+      preload: path.join(app.getAppPath(), 'preload.js'),
+      nodeIntegration: true,
+      contextIsolation: true,
+    },
+  });
+  const indexPath = path.join(app.getAppPath(), 'build/index.html');
+  mainWindow.loadURL(`file://${indexPath}`);
+
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
+
+  ipcMain.on('config', (event, arg) => {
+    store.set('port', arg.port);
+    store.set('device_xml', arg.device_xml);
+  });
+};
 
 app.whenReady().then(() => {
   child = startFlaskServer();

--- a/main.js
+++ b/main.js
@@ -135,6 +135,10 @@ const createWindow = () => {
   ipcMain.on('config', (event, arg) => {
     store.set('port', arg.port);
     store.set('device_xml', arg.device_xml);
+
+    child.kill();
+    child = startFlaskServer();
+    mainWindow.reload();
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,9 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
+    "antd": "^5.15.4",
     "electron": "^28.2.2",
+    "electron-store": "^8.2.0",
     "moment": "^2.30.1",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,6 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('ipcAPI', {
+  loadPreferences: (channel, listener) => ipcRenderer.on(channel, listener),
+  send: (channel, data) => ipcRenderer.send(channel, data),
+});

--- a/src/App.js
+++ b/src/App.js
@@ -25,6 +25,7 @@ import SOCSummaryComponent from './components/SOCSummaryComponent';
 import TypicalWorstComponent from './components/TypicalWorstComponent';
 import Notes from './components/Notes';
 import Preferences from './preferences';
+import { useSelection } from './SelectionProvider';
 
 function App() {
   const timeFormat = 'MMM DD, YYYY h:mm:ss a';
@@ -43,6 +44,7 @@ function App() {
   const [notes, setNotes] = React.useState('');
   const [topLevel, setTopLevel] = React.useState('');
   const [config, setConfig] = React.useState({});
+  const { toggleItemSelection } = useSelection();
 
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   const showModal = () => {
@@ -55,6 +57,16 @@ function App() {
   const handleCancel = () => {
     setIsModalOpen(false);
   };
+
+  function getKeyByValue(object, value) {
+    return Object.keys(object).find((key) => object[key] === value);
+  }
+
+  React.useEffect(() => {
+    const key = getKeyByValue(Table, openedTable);
+    toggleItemSelection(key);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [openedTable]);
 
   React.useEffect(() => server.GET(server.devices, setDevices), []);
 
@@ -114,8 +126,11 @@ function App() {
     <div>
       <div className="app-main-container">
         <div className="top-container">
-          <div className="top-l1">
-            <DeviceList devices={devices} setDevice={deviceChanged} />
+          <div className="top-l1" onClick={() => setOpenedTable(Table.Summary)}>
+            <DeviceList
+              devices={devices}
+              setDevice={deviceChanged}
+            />
           </div>
           <div className="top-l2">
             <SOCComponent
@@ -240,6 +255,10 @@ function App() {
       {
         openedTable === Table.Peripherals
         && <PeripheralsTable device={device} />
+      }
+      {
+        openedTable === Table.Summary
+        && <div>Summary</div>
       }
       {modalOpen && (
       <Notes

--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,7 @@ import FPGASummaryComponent from './components/FPGASummaryComponent';
 import SOCSummaryComponent from './components/SOCSummaryComponent';
 import TypicalWorstComponent from './components/TypicalWorstComponent';
 import Notes from './components/Notes';
+import Preferences from './preferences';
 
 function App() {
   const timeFormat = 'MMM DD, YYYY h:mm:ss a';
@@ -41,8 +42,30 @@ function App() {
   const [modalOpen, setModalOpen] = React.useState(false);
   const [notes, setNotes] = React.useState('');
   const [topLevel, setTopLevel] = React.useState('');
+  const [config, setConfig] = React.useState({});
+
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const showModal = () => {
+    setIsModalOpen(true);
+  };
+  const handleOk = () => {
+    setIsModalOpen(false);
+    window.ipcAPI.send('config', config);
+  };
+  const handleCancel = () => {
+    setIsModalOpen(false);
+  };
 
   React.useEffect(() => server.GET(server.devices, setDevices), []);
+
+  React.useEffect(() => {
+    if ((typeof window !== 'undefined')) {
+      window.ipcAPI.loadPreferences('preferences', (event, data) => {
+        setConfig(data);
+        showModal();
+      });
+    }
+  }, []);
 
   const deviceChanged = (newDevice) => {
     setDevice(newDevice);
@@ -81,6 +104,10 @@ function App() {
   const handleLangChange = (val) => {
     // implementation TBD
     console.log(val);
+  };
+
+  const handleConfigChange = (name, val) => {
+    setConfig({ ...config, [name]: val });
   };
 
   return (
@@ -223,6 +250,13 @@ function App() {
         onSubmit={handleNotesChange}
       />
       )}
+      <Preferences
+        isModalOpen={isModalOpen}
+        config={config}
+        handleOk={handleOk}
+        handleCancel={handleCancel}
+        handleConfigChange={handleConfigChange}
+      />
     </div>
   );
 }

--- a/src/SelectionProvider.js
+++ b/src/SelectionProvider.js
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const SelectionContext = createContext();
+
+export const useSelection = () => {
+  const context = useContext(SelectionContext);
+  if (!context) {
+    throw new Error('useSelection must be used within a SelectionProvider');
+  }
+  return context;
+};
+
+export function SelectionProvider({ children }) {
+  const [selectedItem, setSelectedItem] = useState('Clocking');
+
+  const toggleItemSelection = (item) => {
+    setSelectedItem(item);
+  };
+
+  const clearSelection = () => {
+    setSelectedItem('');
+  };
+
+  return (
+    // eslint-disable-next-line react/jsx-no-constructed-context-values
+    <SelectionContext.Provider value={{ selectedItem, toggleItemSelection, clearSelection }}>
+      {children}
+    </SelectionContext.Provider>
+  );
+}

--- a/src/components/ConnectivityComponent.js
+++ b/src/components/ConnectivityComponent.js
@@ -3,6 +3,7 @@ import CPUComponent from './CPUComponent';
 import * as server from '../utils/serverAPI';
 import { subscribe, unsubscribe } from '../utils/events';
 import { State } from '../utils/common';
+import { useSelection } from '../SelectionProvider';
 
 function ConnectivityComponent({ device }) {
   const [name, setName] = React.useState('');
@@ -11,6 +12,7 @@ function ConnectivityComponent({ device }) {
   const [ep2, setEp2] = React.useState(0);
   const [ep3, setEp3] = React.useState(0);
   const [power, setPower] = React.useState(0);
+  const { selectedItem } = useSelection();
   const endpoints = [
     'Channel 1', 'Channel 2', 'Channel 3', 'Channel 4',
   ];
@@ -47,11 +49,16 @@ function ConnectivityComponent({ device }) {
 
   const warn = 0.003; // TBD
   const error = 0.016; // TBD
+  const Title = 'Connectivity';
+
+  function getBaseName() {
+    return (selectedItem === Title) ? 'clickable selected' : 'clickable';
+  }
 
   return (
-    <State refValue={power} warn={warn} err={error}>
+    <State refValue={power} warn={warn} err={error} baseClass={getBaseName()}>
       <CPUComponent
-        title="Connectivity"
+        title={Title}
         power={power}
         name={name}
         ep0={ep0}

--- a/src/components/DMAComponent.js
+++ b/src/components/DMAComponent.js
@@ -3,6 +3,7 @@ import CPUComponent from './CPUComponent';
 import * as server from '../utils/serverAPI';
 import { subscribe, unsubscribe } from '../utils/events';
 import { State } from '../utils/common';
+import { useSelection } from '../SelectionProvider';
 
 function DMAComponent({ device }) {
   const [ep0, setEp0] = React.useState(0);
@@ -10,6 +11,7 @@ function DMAComponent({ device }) {
   const [ep2, setEp2] = React.useState(0);
   const [ep3, setEp3] = React.useState(0);
   const [power, setPower] = React.useState(0);
+  const { selectedItem } = useSelection();
 
   function fetchEndPoint(href, setEp) {
     server.GET(server.peripheralPath(device, href), (data) => setEp(data.consumption.noc_power));
@@ -45,11 +47,16 @@ function DMAComponent({ device }) {
 
   const warn = 0.001; // TBD
   const error = 0.016; // TBD
+  const Title = 'DMA';
+
+  function getBaseName() {
+    return (selectedItem === Title) ? 'clickable selected' : 'clickable';
+  }
 
   return (
-    <State refValue={power} warn={warn} err={error}>
+    <State refValue={power} warn={warn} err={error} baseClass={getBaseName()}>
       <CPUComponent
-        title="DMA"
+        title={Title}
         power={power}
         name={null}
         ep0={ep0}

--- a/src/components/DeviceList.js
+++ b/src/components/DeviceList.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import * as server from '../utils/serverAPI';
-
+import { useSelection } from '../SelectionProvider';
 import './style/DeviceList.css';
 
 function DeviceList({ devices, setDevice }) {
   const [deviceInfo, setDeviceInfo] = React.useState({});
+  const { selectedItem } = useSelection();
+  const [selectedDevice, setSelectedDevice] = React.useState('selectDev');
 
   function getDeviceInfo(id) {
     server.GET(server.deviceInfo(id), (data) => setDeviceInfo(data));
@@ -12,13 +14,18 @@ function DeviceList({ devices, setDevice }) {
 
   function DeviceOnChange(event) {
     const deviceId = event.target.value;
+    setSelectedDevice(deviceId);
     getDeviceInfo(deviceId);
     setDevice(deviceId);
   }
 
+  function getBaseName() {
+    return (selectedItem === 'Summary') ? 'dev-table selected' : 'dev-table';
+  }
+
   return (
     <div className="dev-table-container">
-      <table className="dev-table">
+      <table className={getBaseName()}>
         <thead>
           <tr>
             <td>
@@ -32,8 +39,9 @@ function DeviceList({ devices, setDevice }) {
                   id="deviceId"
                   className="dev-selector"
                   onChange={DeviceOnChange}
+                  value={selectedDevice}
                 >
-                  <option key="" value="">
+                  <option key="" value="selectDev" disabled>
                     Select a device...
                   </option>
                   {devices.map((data) => (

--- a/src/components/FpgaCell.js
+++ b/src/components/FpgaCell.js
@@ -1,14 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { fixed, State } from '../utils/common';
+import { useSelection } from '../SelectionProvider';
 
 import './style/base.css';
 
 function FpgaCell({
   power, powerWarm, powerErr, title,
 }) {
+  const { selectedItem } = useSelection();
+  function getBaseClass() {
+    return (selectedItem === title) ? 'clickable selected' : 'clickable';
+  }
   return (
-    <State refValue={power} warn={powerWarm} err={powerErr}>
+    <State refValue={power} warn={powerWarm} err={powerErr} baseClass={getBaseClass()}>
       <div className="bold-text-title">{title}</div>
       <div className="grayed-text">
         {fixed(power)}

--- a/src/components/MemoryComponent.js
+++ b/src/components/MemoryComponent.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import * as server from '../utils/serverAPI';
 import { fixed, State } from '../utils/common';
 import { subscribe, unsubscribe } from '../utils/events';
+import { useSelection } from '../SelectionProvider';
 
 import './style/MemoryComponent.css';
 
@@ -24,6 +25,7 @@ function MemoryComponent({ device }) {
     },
   ]);
   const [power, setPower] = React.useState(0);
+  const { selectedItem } = useSelection();
 
   function update() {
     server.GET(server.api.consumption(server.Elem.peripherals, device), (data) => {
@@ -59,10 +61,15 @@ function MemoryComponent({ device }) {
   const warn = 0.001; // TBD
   const error = 0.016; // TBD
 
+  const Title = 'Memory';
+  function getBaseClass() {
+    return (selectedItem === Title) ? 'mem-container selected' : 'mem-container';
+  }
+
   return (
-    <State refValue={power} warn={warn} err={error} baseClass="mem-container">
+    <State refValue={power} warn={warn} err={error} baseClass={getBaseClass()}>
       <div className="mem-line">
-        <div className="bold-text">Memory</div>
+        <div className="bold-text">{Title}</div>
         <div className="grayed-text bold-text mem-value">
           {fixed(power)}
           {' W'}

--- a/src/components/PeripheralsComponent.js
+++ b/src/components/PeripheralsComponent.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Table, fixed, State } from '../utils/common';
 import * as server from '../utils/serverAPI';
+import { useSelection } from '../SelectionProvider';
 
 import './style/Peripherals.css';
 
@@ -15,6 +16,7 @@ function PeripheralsComponent({ setOpenedTable, device }) {
   const [uart1, setUart1] = React.useState(0);
   const [gpio, setGPIO] = React.useState(0);
   const [power, setPower] = React.useState(0);
+  const { selectedItem } = useSelection();
 
   function fetchPeripherals(deviceId, key, url) {
     server.GET(server.peripheralPath(deviceId, url), (data) => {
@@ -46,13 +48,22 @@ function PeripheralsComponent({ setOpenedTable, device }) {
     }
   }, [device]);
 
+  const Title = 'Peripherals';
+
+  function getClassName() {
+    return (selectedItem === Title) ? 'periph-top selected' : 'periph-top';
+  }
+
   const warn = 0.001; // TBD
   const error = 0.016; // TBD
 
   return (
-    <div className="periph-top" onClick={() => setOpenedTable(Table.Peripherals)}>
+    <div
+      className={getClassName()}
+      onClick={() => setOpenedTable(Table.Peripherals)}
+    >
       <div className="periph-row-head">
-        <div>Peripherals</div>
+        <div>{Title}</div>
         <div id="peripherals-power" className="grayed-text">
           {fixed(power)}
           {' W'}

--- a/src/components/SOCComponent.js
+++ b/src/components/SOCComponent.js
@@ -8,6 +8,7 @@ import DMAComponent from './DMAComponent';
 import ConnectivityComponent from './ConnectivityComponent';
 import { subscribe, unsubscribe } from '../utils/events';
 import * as server from '../utils/serverAPI';
+import { useSelection } from '../SelectionProvider';
 
 import './style/SOCTable.css';
 
@@ -16,6 +17,7 @@ function SOCTable({ device, setOpenedTable }) {
   const [staticPower, setStaticPower] = React.useState(0);
   const [acpuPower, setAcpuPower] = React.useState(0);
   const [bcpuPower, setBcpuPower] = React.useState(0);
+  const { selectedItem } = useSelection();
 
   function componentChanged() {
     if (device !== null) {
@@ -57,11 +59,15 @@ function SOCTable({ device, setOpenedTable }) {
   const warn = 0.003; // TBD
   const error = 0.016; // TBD
 
+  function getBaseName(item) {
+    return (selectedItem === item) ? 'clickable selected' : 'clickable';
+  }
+
   return (
     <div className="top-l2-col1">
       <div className="top-l2-col1-row1">
         <div className="top-l2-col1-row1-elem" onClick={() => setOpenedTable(Table.ACPU)}>
-          <State refValue={acpuPower} warn={warn} err={error}>
+          <State refValue={acpuPower} warn={warn} err={error} baseClass={getBaseName('ACPU')}>
             <ABCPUComponent
               device={device}
               title="ACPU"
@@ -71,7 +77,7 @@ function SOCTable({ device, setOpenedTable }) {
           </State>
         </div>
         <div className="top-l2-col1-row1-elem" onClick={() => setOpenedTable(Table.BCPU)}>
-          <State refValue={bcpuPower} warn={warn} err={error}>
+          <State refValue={bcpuPower} warn={warn} err={error} baseClass={getBaseName('BCPU')}>
             <ABCPUComponent
               device={device}
               title="BCPU"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,13 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { SelectionProvider } from './SelectionProvider';
 
 const root = createRoot(document.getElementById('app'));
-root.render(<App />);
+root.render(
+  <React.StrictMode>
+    <SelectionProvider>
+      <App />
+    </SelectionProvider>
+  </React.StrictMode>,
+);

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Modal } from 'antd';
+
+function Preferences({
+  isModalOpen, config, handleOk, handleCancel, handleConfigChange,
+}) {
+  return (
+    <Modal title="Preferences" open={isModalOpen} onOk={handleOk} onCancel={handleCancel}>
+      <div className="form-group">
+        <label>Port</label>
+        <input
+          type="number"
+          step={1}
+          min={0}
+          name="port"
+          onChange={(e) => handleConfigChange(e.target.name, parseInt(e.target.value, 10))}
+        // eslint-disable-next-line no-nested-ternary
+          value={config.port}
+        />
+      </div>
+      <div className="form-group">
+        <label>Devices file</label>
+        <input
+          type="text"
+          name="device_xml"
+          onChange={handleConfigChange}
+        // eslint-disable-next-line no-nested-ternary
+          value={config.device_xml}
+        />
+      </div>
+    </Modal>
+  );
+}
+
+export default Preferences;

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -4,6 +4,8 @@ import { Modal } from 'antd';
 function Preferences({
   isModalOpen, config, handleOk, handleCancel, handleConfigChange,
 }) {
+  const [warning, setWarnig] = React.useState(false);
+  React.useEffect(() => setWarnig(false), [isModalOpen]);
   return (
     <Modal title="Preferences" open={isModalOpen} onOk={handleOk} onCancel={handleCancel}>
       <div className="form-group">
@@ -13,7 +15,10 @@ function Preferences({
           step={1}
           min={0}
           name="port"
-          onChange={(e) => handleConfigChange(e.target.name, parseInt(e.target.value, 10))}
+          onChange={(e) => {
+            handleConfigChange(e.target.name, parseInt(e.target.value, 10));
+            setWarnig(true);
+          }}
         // eslint-disable-next-line no-nested-ternary
           value={config.port}
         />
@@ -23,11 +28,17 @@ function Preferences({
         <input
           type="text"
           name="device_xml"
-          onChange={(e) => handleConfigChange(e.target.name, e.target.value)}
+          onChange={(e) => {
+            handleConfigChange(e.target.name, e.target.value);
+            setWarnig(true);
+          }}
         // eslint-disable-next-line no-nested-ternary
           value={config.device_xml}
         />
       </div>
+      {
+        warning && <label className="warningLabel">Application will be reloaded</label>
+      }
     </Modal>
   );
 }

--- a/src/preferences.js
+++ b/src/preferences.js
@@ -23,7 +23,7 @@ function Preferences({
         <input
           type="text"
           name="device_xml"
-          onChange={handleConfigChange}
+          onChange={(e) => handleConfigChange(e.target.name, e.target.value)}
         // eslint-disable-next-line no-nested-ternary
           value={config.device_xml}
         />

--- a/src/style.css
+++ b/src/style.css
@@ -10,6 +10,7 @@
 
 .top-l1 {
     border-bottom: 2px solid #908f8f;
+    cursor: pointer;
 }
 
 .top-l2 {
@@ -109,4 +110,8 @@
     font-weight: bold;
     padding-top: 10px;
     padding-bottom: 10px;
+}
+
+.selected {
+    outline: 3px solid #3385FF;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -44,10 +44,9 @@
 .pt-group input,
 .pt-group textarea,
 .pt-group select {
-  border: none;
-  border-radius: 0.3rem;
-  padding: 0.3rem;
-  /* font-size: 1rem; */
+    border: none;
+    border-radius: 0.3rem;
+    padding: 0.3rem;
 }
 
 .last-time {
@@ -103,4 +102,11 @@
     align-content: center;
     border-left: 1px solid #828282;
     padding-left: 2px;
+}
+
+.warningLabel {
+    color: red;
+    font-weight: bold;
+    padding-top: 10px;
+    padding-bottom: 10px;
 }

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -12,6 +12,7 @@ export const Table = {
   Memory: 8,
   BCPU: 9,
   DMA: 10,
+  Summary: 11,
 };
 
 export const formatString = (template, ...args) => template.replace(/{([0-9]+)}/g, (match, index) => (typeof args[index] === 'undefined' ? match : args[index]));


### PR DESCRIPTION
Updates:
* Preferences menu allow change port and device.xml path.
* Restart application when settings changed.
* Enable persistence user data (electron-store). Now we can persist any data between sessions.
* Organize IPC communication between main process and renderer process.
* preload.js script now is available. 
* Indicate selected element
* Make device selection component selectable. 

![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/19bd8bc7-560d-4caa-becf-e276b523eb29)

With warning:
![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/f44b2583-8359-4597-aeb4-a878d218d1fa)

Selection:
![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/d80aadd7-fad6-4f82-b019-c47187e38c2f)
