### PR TITLE
Update Rapid Power Estimator to upload package tar file on every push

### DIFF
--- a/.github/workflows/rpe_test.yml
+++ b/.github/workflows/rpe_test.yml
@@ -167,7 +167,6 @@ jobs:
       - name: Create Package on ${{ matrix.os }}
         if: ${{ matrix.os == 'macos-latest' || matrix.os == 'windows-latest' }}
         run: |
-             pyinstaller --distpath backend --workpath dist -y --clean -n restapi_server.exe --onefile  backend/restapi_server.py
              npm run dist
         env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -183,7 +182,6 @@ jobs:
                 cd /work
                 npm install
                 python3 -m pip install -r requirements.txt
-                pyinstaller --distpath backend --workpath dist -y --clean -n restapi_server.exe --onefile  backend/restapi_server.py
                 npm run dist
                 ls dist
                 tar -czvf rapid_power_estimator.tar.gz -C dist/linux-unpacked .

--- a/.github/workflows/rpe_test.yml
+++ b/.github/workflows/rpe_test.yml
@@ -100,7 +100,6 @@ jobs:
         run: python3 -m pytest
 
   publish:
-#    if: startsWith(github.ref, 'refs/tags/')
     needs: build 	
     strategy:
       fail-fast: false
@@ -189,20 +188,21 @@ jobs:
         env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Run on refs/tags only
+        run: |
+            echo ${{ github.ref }} 
+
       - name: Upload Package
-        if: ${{ matrix.os != 'ubuntu-latest' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@v3
         with:
             name: rapid_power_estimator_${{ matrix.os }}
-            path: dist/rapid_power_estimator*.tar.gz*
- 
-      - name: Run on refs/tags only
-        run: |
-            echo ${{ github.ref }}     
+            path: dist/rapid_power_estimator*.tar.gz*    
 
-  #    - name: Upload Release
-  #      uses: softprops/action-gh-release@v1
-  #      with:
-  #          files: dist/rapid_power_estimator*.tar.gz*
+      - name: Upload Release
+  	if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+            files: dist/rapid_power_estimator*.tar.gz*
 
 

--- a/.github/workflows/rpe_test.yml
+++ b/.github/workflows/rpe_test.yml
@@ -191,12 +191,12 @@ jobs:
         env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-#      - name: Upload Package
-#        if: ${{ matrix.os != 'ubuntu-latest' }}
-#        uses: actions/upload-artifact@v3
-#        with:
-#            name: rapid_power_estimator_${{ matrix.os }}
-#            path: dist/rapid_power_estimator*.tar.gz*
+      - name: Upload Package
+        if: ${{ matrix.os != 'ubuntu-latest' }}
+        uses: actions/upload-artifact@v3
+        with:
+            name: rapid_power_estimator_${{ matrix.os }}
+            path: dist/rapid_power_estimator*.tar.gz*
  
       - name: Run on refs/tags only
         run: |

--- a/.github/workflows/rpe_test.yml
+++ b/.github/workflows/rpe_test.yml
@@ -200,7 +200,7 @@ jobs:
             path: dist/rapid_power_estimator*.tar.gz*    
 
       - name: Upload Release
-  	if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
             files: dist/rapid_power_estimator*.tar.gz*

--- a/.github/workflows/rpe_test.yml
+++ b/.github/workflows/rpe_test.yml
@@ -100,7 +100,7 @@ jobs:
         run: python3 -m pytest
 
   publish:
-    if: startsWith(github.ref, 'refs/tags/')
+#    if: startsWith(github.ref, 'refs/tags/')
     needs: build 	
     strategy:
       fail-fast: false
@@ -202,9 +202,9 @@ jobs:
         run: |
             echo ${{ github.ref }}     
 
-      - name: Upload Release
-        uses: softprops/action-gh-release@v1
-        with:
-            files: dist/rapid_power_estimator*.tar.gz*
+  #    - name: Upload Release
+  #      uses: softprops/action-gh-release@v1
+  #      with:
+  #          files: dist/rapid_power_estimator*.tar.gz*
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 restapi_server.spec
+restapi_server.exe.spec
+backend/restapi_server.exe
 
 # C extensions
 *.so

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
       "build/**/*",
       "src/**/*",
       "main.js",
+      "preload.js",
       "rpe.config.json",
       "node_modules/**/*",
       "package.json"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "electron-builder install-app-deps",
     "pack": "electron-builder --dir",
-    "dist": "webpack && electron-builder"
+    "dist": "pyinstaller --distpath backend --workpath dist -y --clean -n restapi_server.exe --onefile  backend/restapi_server.py && webpack && electron-builder"
   },
   "build": {
     "appId": "org.rapidsilicon.rapid_power_estimator",


### PR DESCRIPTION
Added preload.js in package
pyinstaller command is now part of the dist command
Upload artifacts on every push to the main branch
Upload to package to release area on push of git tag