### PR TITLE
Update thermal table

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -211,71 +211,72 @@ function App() {
           <SOCSummaryComponent device={device} />
         </div>
       </div>
-      <div className="hspacer" />
-      {
+      <div className="table-container">
+        {
         openedTable === Table.Clocking
         && <ClockingTable device={device} totalPowerCallback={setClockingPower} />
-      }
-      {
+        }
+        {
         openedTable === Table.FLE
         && <FleTable device={device} totalPowerCallback={setFlePower} />
-      }
-      {
+        }
+        {
         openedTable === Table.IO
         && <IOTable device={device} totalPowerCallback={setIoPower} />
-      }
-      {
+        }
+        {
         openedTable === Table.BRAM
         && <BramTable device={device} totalPowerCallback={setBramPower} />
-      }
-      {
+        }
+        {
         openedTable === Table.DSP
         && <DspTable device={device} totalPowerCallback={setDspPower} />
-      }
-      {
+        }
+        {
         openedTable === Table.ACPU
         && <ACPUTable device={device} />
-      }
-      {
+        }
+        {
         openedTable === Table.BCPU
         && <BCPUTable device={device} />
-      }
-      {
+        }
+        {
         openedTable === Table.Connectivity
         && <ConnectivityTable device={device} />
-      }
-      {
+        }
+        {
         openedTable === Table.Memory
         && <MemoryTable device={device} />
-      }
-      {
+        }
+        {
         openedTable === Table.DMA
         && <DMATable device={device} />
-      }
-      {
+        }
+        {
         openedTable === Table.Peripherals
         && <PeripheralsTable device={device} />
-      }
-      {
+        }
+        {
         openedTable === Table.Summary
         && <DesignParametesTable />
-      }
-      {modalOpen && (
-      <Notes
-        defaultValue={notes}
-        closeModal={() => {
-          setModalOpen(false);
-        }}
-        onSubmit={handleNotesChange}
-      />
-      )}
-      <Preferences
-        isModalOpen={isModalOpen}
-        config={config}
-        handleOk={handleOk}
-        handleCancel={handleCancel}
-        handleConfigChange={handleConfigChange}
-      />
+        }
+        {modalOpen && (
+        <Notes
+          defaultValue={notes}
+          closeModal={() => {
+            setModalOpen(false);
+          }}
+          onSubmit={handleNotesChange}
+        />
+        )}
+        <Preferences
+          isModalOpen={isModalOpen}
+          config={config}
+          handleOk={handleOk}
+          handleCancel={handleCancel}
+          handleConfigChange={handleConfigChange}
+        />
+      </div>
     </div>
   );
 }

--- a/src/SOCTotalPowerProvider.js
+++ b/src/SOCTotalPowerProvider.js
@@ -24,6 +24,16 @@ export function SocTotalPowerProvider({ children }) {
     total_soc_io_available: 0,
     total_soc_io_used: 0,
   });
+  const [thermalData, setThermalData] = React.useState({
+    typical: {
+      total_power: 0,
+      thermal: 0,
+    },
+    worsecase: {
+      total_power: 0,
+      thermal: 0,
+    },
+  });
 
   const updateTotalPower = (device) => {
     if (device !== null) {
@@ -36,15 +46,23 @@ export function SocTotalPowerProvider({ children }) {
             + data.total_noc_interconnect_power
             + data.total_memory_power);
       });
+      server.GET(server.api.consumption('', device), (data) => {
+        setThermalData(data);
+      });
       // todo, pending for backend implementation
       setStaticPower(0);
     }
   };
 
+  const calcPercents = (totalPower) => {
+    if (thermalData.worsecase.total_power === 0) return 0;
+    return (totalPower / thermalData.worsecase.total_power) * 100;
+  };
+
   return (
     // eslint-disable-next-line react/jsx-no-constructed-context-values
     <SocTotalPowerContext.Provider value={{
-      power, dynamicPower, staticPower, updateTotalPower,
+      power, dynamicPower, staticPower, thermalData, updateTotalPower, calcPercents,
     }}
     >
       {children}

--- a/src/components/ComponentsLib.js
+++ b/src/components/ComponentsLib.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { BsPlus } from 'react-icons/bs';
+import './style/ComponentsLib.css';
+
+export function State({
+  refValue, warn, err, baseClass = 'clickable', children,
+}) {
+  const buildClassName = React.useCallback(() => {
+    let base = baseClass;
+    if (refValue >= err) base += ' error';
+    else if (refValue >= warn) base += ' warning';
+    else base += ' normal';
+    return base;
+  }, [refValue, warn, err, baseClass]);
+  return (
+    <div className={buildClassName()}>
+      {children}
+    </div>
+  );
+}
+
+export function ComponentLabel({ name }) {
+  return (
+    <div className="layout-head">
+      <div className="component-label-text-center">
+        FPGA
+      </div>
+      <div className="component-label-text-center">
+        &gt;
+      </div>
+      <div className="component-label">
+        {name}
+      </div>
+    </div>
+  );
+}
+
+export function AddButton({ disabled, onClick }) {
+  return (
+    <button className="button" type="button" disabled={disabled} onClick={onClick}>
+      <div className="icon-container">
+        <BsPlus color="#007bff" className="icon" />
+      </div>
+      Add
+    </button>
+  );
+}

--- a/src/components/ConnectivityComponent.js
+++ b/src/components/ConnectivityComponent.js
@@ -2,9 +2,10 @@ import React from 'react';
 import CPUComponent from './CPUComponent';
 import * as server from '../utils/serverAPI';
 import { subscribe, unsubscribe } from '../utils/events';
-import { State, percentage } from '../utils/common';
+import { percentage } from '../utils/common';
 import { useSelection } from '../SelectionProvider';
 import { useSocTotalPower } from '../SOCTotalPowerProvider';
+import { State } from './ComponentsLib';
 
 function ConnectivityComponent({ device }) {
   const [name, setName] = React.useState('');

--- a/src/components/DMAComponent.js
+++ b/src/components/DMAComponent.js
@@ -2,9 +2,10 @@ import React from 'react';
 import CPUComponent from './CPUComponent';
 import * as server from '../utils/serverAPI';
 import { subscribe, unsubscribe } from '../utils/events';
-import { State, percentage } from '../utils/common';
+import { percentage } from '../utils/common';
 import { useSelection } from '../SelectionProvider';
 import { useSocTotalPower } from '../SOCTotalPowerProvider';
+import { State } from './ComponentsLib';
 
 function DMAComponent({ device }) {
   const [ep0, setEp0] = React.useState(0);

--- a/src/components/FPGASummaryComponent.js
+++ b/src/components/FPGASummaryComponent.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import PowerSummaryTable from './Tables/PowerSummaryTable';
 import { percentage } from '../utils/common';
+import { useSocTotalPower } from '../SOCTotalPowerProvider';
 
 function FPGASummaryComponent({
   device, clocking, fle, dsp, bram, io,
@@ -43,6 +44,7 @@ function FPGASummaryComponent({
       percent: 0,
     },
   ]);
+  const { calcPercents } = useSocTotalPower();
 
   React.useEffect(() => {
     const newData = data;
@@ -71,7 +73,7 @@ function FPGASummaryComponent({
       title="FPGA Complex and Core Power"
       data={data}
       total={data[5].power + data[6].power}
-      percent={0}
+      percent={calcPercents(data[5].power + data[6].power)}
     />
   );
 }

--- a/src/components/FpgaCell.js
+++ b/src/components/FpgaCell.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { fixed, State } from '../utils/common';
+import { fixed } from '../utils/common';
 import { useSelection } from '../SelectionProvider';
+import { State } from './ComponentsLib';
 
 import './style/base.css';
 

--- a/src/components/MemoryComponent.js
+++ b/src/components/MemoryComponent.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as server from '../utils/serverAPI';
-import { fixed, State, percentage } from '../utils/common';
+import { fixed, percentage } from '../utils/common';
 import { subscribe, unsubscribe } from '../utils/events';
 import { useSelection } from '../SelectionProvider';
 import { useSocTotalPower } from '../SOCTotalPowerProvider';
+import { State } from './ComponentsLib';
 
 import './style/MemoryComponent.css';
 

--- a/src/components/PeripheralsComponent.js
+++ b/src/components/PeripheralsComponent.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import {
-  Table, fixed, State, percentage,
-} from '../utils/common';
+import { Table, fixed, percentage } from '../utils/common';
 import * as server from '../utils/serverAPI';
 import { useSelection } from '../SelectionProvider';
 import { useSocTotalPower } from '../SOCTotalPowerProvider';
+import { State } from './ComponentsLib';
 
 import './style/Peripherals.css';
 

--- a/src/components/SOCComponent.js
+++ b/src/components/SOCComponent.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import PeripheralsComponent from './PeripheralsComponent';
-import { Table, State, percentage } from '../utils/common';
+import { Table, percentage } from '../utils/common';
 import TitleComponent from './TitleComponent';
 import ABCPUComponent from './ABCPUComponent';
 import DMAComponent from './DMAComponent';
 import ConnectivityComponent from './ConnectivityComponent';
 import { useSelection } from '../SelectionProvider';
 import { useSocTotalPower } from '../SOCTotalPowerProvider';
+import { State } from './ComponentsLib';
 
 import './style/SOCTable.css';
 

--- a/src/components/SOCSummaryComponent.js
+++ b/src/components/SOCSummaryComponent.js
@@ -47,7 +47,9 @@ function SOCSummaryComponent({ device }) {
       percent: 0,
     },
   ]);
-  const { power, dynamicPower, staticPower } = useSocTotalPower();
+  const {
+    power, dynamicPower, staticPower, calcPercents,
+  } = useSocTotalPower();
 
   React.useEffect(() => {
     if (device !== null) {
@@ -78,7 +80,7 @@ function SOCSummaryComponent({ device }) {
       title="Processing Complex (SOC) Power"
       data={data}
       total={data[6].power + data[7].power}
-      percent={0}
+      percent={calcPercents(data[6].power + data[7].power)}
     />
   );
 }

--- a/src/components/Tables/ACPUTable.js
+++ b/src/components/Tables/ACPUTable.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FaPlus } from 'react-icons/fa6';
 import PowerTable from './PowerTable';
 import * as server from '../../utils/serverAPI';
 import { acpuNames, loadActivity, findEvailableIndex } from '../../utils/cpu';
@@ -9,6 +8,7 @@ import { PowerCell, SelectionCell, PercentsCell } from './TableCells';
 import { GetText } from '../../utils/common';
 import { publish } from '../../utils/events';
 import { useSocTotalPower } from '../../SOCTotalPowerProvider';
+import { ComponentLabel } from '../ComponentsLib';
 
 import '../style/ACPUTable.css';
 
@@ -95,7 +95,7 @@ function ACPUTable({ device }) {
     updateTotalPower(device);
   };
 
-  const header = ['Endpoint', 'Activity', 'R/W', 'Toggle Rate', 'Bandwidth', 'Noc Power', 'Action'];
+  const header = ['Action', 'Endpoint', 'Activity', 'R/W', 'Toggle Rate', 'Bandwidth', 'Noc Power'];
 
   function modifyRow(index, row) {
     const data = row;
@@ -131,10 +131,7 @@ function ACPUTable({ device }) {
   return (
     <div className="acpu-container main-border">
       <div className="main-block">
-        <div className="layout-head">
-          <label>FPGA &gt; ACPU</label>
-          <button type="button" disabled={addButtonDisable} className="plus-button" onClick={() => setModalOpen(true)}><FaPlus /></button>
-        </div>
+        <ComponentLabel name="ACPU" />
         <div className="cpu-container">
           <PowerTable
             title="ACPU power"
@@ -163,22 +160,22 @@ function ACPUTable({ device }) {
               </select>
             </div>
           </div>
-          <TableBase header={header}>
+          <TableBase header={header} disabled={addButtonDisable} onClick={() => setModalOpen(true)}>
             {
               endpoints.map((row, index) => (
                 (row.data !== undefined && row.data.name !== '')
                 && (
                 <tr key={row.ep}>
+                  <Actions
+                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                    onDeleteClick={() => deleteRow(index)}
+                  />
                   <td>{row.data.name}</td>
                   <SelectionCell val={row.data.activity} values={loadActivity} />
                   <PercentsCell val={row.data.read_write_rate} />
                   <PercentsCell val={row.data.toggle_rate} precition={1} />
                   <PowerCell val={row.data.consumption.calculated_bandwidth} />
                   <PowerCell val={row.data.consumption.noc_power} />
-                  <Actions
-                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                    onDeleteClick={() => deleteRow(index)}
-                  />
                 </tr>
                 )
               ))

--- a/src/components/Tables/BCPUTable.js
+++ b/src/components/Tables/BCPUTable.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FaPlus } from 'react-icons/fa6';
 import PowerTable from './PowerTable';
 import * as server from '../../utils/serverAPI';
 import {
@@ -11,6 +10,7 @@ import { PowerCell, SelectionCell, PercentsCell } from './TableCells';
 import { GetText } from '../../utils/common';
 import { publish } from '../../utils/events';
 import { useSocTotalPower } from '../../SOCTotalPowerProvider';
+import { ComponentLabel } from '../ComponentsLib';
 
 import '../style/ACPUTable.css';
 
@@ -103,7 +103,7 @@ function BCPUTable({ device }) {
     updateTotalPower(device);
   };
 
-  const header = ['Endpoint', 'Activity', 'R/W', 'Toggle Rate', 'Bandwidth', 'Noc Power', 'Action'];
+  const header = ['Action', 'Endpoint', 'Activity', 'R/W', 'Toggle Rate', 'Bandwidth', 'Noc Power'];
 
   function modifyRow(index, row) {
     const data = row;
@@ -145,10 +145,7 @@ function BCPUTable({ device }) {
   return (
     <div className="acpu-container main-border">
       <div className="main-block">
-        <div className="layout-head">
-          <label>FPGA &gt; BCPU</label>
-          <button type="button" disabled={addButtonDisable} className="plus-button" onClick={() => setModalOpen(true)}><FaPlus /></button>
-        </div>
+        <ComponentLabel name="BCPU" />
         <div className="cpu-container">
           <PowerTable
             title="BCPU power"
@@ -185,22 +182,22 @@ function BCPUTable({ device }) {
               </select>
             </div>
           </div>
-          <TableBase header={header}>
+          <TableBase header={header} disabled={addButtonDisable} onClick={() => setModalOpen(true)}>
             {
               endpoints.map((row, index) => (
                 (row.data !== undefined && row.data.name !== '')
                 && (
                 <tr key={row.ep}>
+                  <Actions
+                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                    onDeleteClick={() => deleteRow(index)}
+                  />
                   <td>{row.data.name}</td>
                   <SelectionCell val={row.data.activity} values={loadActivity} />
                   <PercentsCell val={row.data.read_write_rate} />
                   <PercentsCell val={row.data.toggle_rate} precition={1} />
                   <PowerCell val={row.data.consumption.calculated_bandwidth} />
                   <PowerCell val={row.data.consumption.noc_power} />
-                  <Actions
-                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                    onDeleteClick={() => deleteRow(index)}
-                  />
                 </tr>
                 )
               ))

--- a/src/components/Tables/BramTable.js
+++ b/src/components/Tables/BramTable.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FaPlus } from 'react-icons/fa6';
 import PowerTable from './PowerTable';
 import * as server from '../../utils/serverAPI';
 import { fixed, GetText } from '../../utils/common';
@@ -7,6 +6,7 @@ import BramModal from '../ModalWindows/BramModal';
 import bramType from '../../utils/bram';
 import { PercentsCell, FrequencyCell, PowerCell } from './TableCells';
 import { TableBase, Actions } from './TableBase';
+import { ComponentLabel } from '../ComponentsLib';
 
 import '../style/ComponentTable.css';
 
@@ -133,17 +133,14 @@ function BramTable({ device, totalPowerCallback }) {
   ];
 
   const mainTableHeader = [
-    'Name/Hierarchy', 'BRAM Type', 'Used', 'Port', 'Clock', 'Width', 'Write En', 'Read En',
-    'Toggle Rate', 'Clock Freq', 'RAM Depth', 'O/P Sig Rate', 'Block Power', 'Intc. Power', '%', 'Action',
+    'Action', 'Name/Hierarchy', 'BRAM Type', 'Used', 'Port', 'Clock', 'Width', 'Write En', 'Read En',
+    'Toggle Rate', 'Clock Freq', 'RAM Depth', 'O/P Sig Rate', 'Block Power', 'Intc. Power', '%',
   ];
 
   return (
     <div className="component-table-head main-border">
       <div className="main-block">
-        <div className="layout-head">
-          <label>FPGA &gt; BRAM</label>
-          <button type="button" className="plus-button" onClick={() => setModalOpen(true)}><FaPlus /></button>
-        </div>
+        <ComponentLabel name="BRAM" />
         <div className="power-and-table-wrapper">
           <div className="power-table-wrapper">
             <PowerTable
@@ -153,11 +150,20 @@ function BramTable({ device, totalPowerCallback }) {
               resources={powerTable}
             />
           </div>
-          <TableBase header={mainTableHeader}>
+          <TableBase
+            header={mainTableHeader}
+            disabled={device === null}
+            onClick={() => setModalOpen(true)}
+          >
             {
             bramData.map((row, index) => (
               <React.Fragment key={row.name}>
                 <tr>
+                  <Actions
+                    rowSpan={2}
+                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                    onDeleteClick={() => deleteRow(index)}
+                  />
                   <td rowSpan={2}>{row.name}</td>
                   <td rowSpan={2}>{GetText(row.type, bramType)}</td>
                   <td rowSpan={2}>{row.bram_used}</td>
@@ -179,11 +185,6 @@ function BramTable({ device, totalPowerCallback }) {
                     {fixed(row.consumption.percentage, 0)}
                     {' %'}
                   </td>
-                  <Actions
-                    rowSpan={2}
-                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                    onDeleteClick={() => deleteRow(index)}
-                  />
                 </tr>
                 <tr>
                   <td>B - Read</td>

--- a/src/components/Tables/ClockingTable.js
+++ b/src/components/Tables/ClockingTable.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FaPlus } from 'react-icons/fa6';
 import ClockingModal from '../ModalWindows/ClockingModal';
 import { sources, states } from '../../utils/clocking';
 import PowerTable from './PowerTable';
@@ -7,6 +6,7 @@ import * as server from '../../utils/serverAPI';
 import { fixed, GetText } from '../../utils/common';
 import { FrequencyCell, PowerCell } from './TableCells';
 import { TableBase, Actions } from './TableBase';
+import { ComponentLabel } from '../ComponentsLib';
 
 import '../style/ComponentTable.css';
 
@@ -18,8 +18,8 @@ function ClockingTable({ device, totalPowerCallback }) {
   const [powerTable, setPowerTable] = React.useState([]);
 
   const mainTableHeader = [
-    'Description', 'Source', 'Port/Signal name', 'Frequency', 'Clock Control', 'Fanout',
-    'Block Power', 'Intc. Power', '%', 'Action',
+    'Action', 'Description', 'Source', 'Port/Signal name', 'Frequency', 'Clock Control', 'Fanout',
+    'Block Power', 'Intc. Power', '%',
   ];
 
   const fetchClockData = (deviceId) => {
@@ -95,10 +95,7 @@ function ClockingTable({ device, totalPowerCallback }) {
   return (
     <div className="component-table-head main-border">
       <div className="main-block">
-        <div className="layout-head">
-          <label>FPGA &gt; Clocking</label>
-          <button type="button" className="plus-button" onClick={() => setModalOpen(true)}><FaPlus /></button>
-        </div>
+        <ComponentLabel name="Clocking" />
         <div className="power-and-table-wrapper">
           <div className="power-table-wrapper">
             <PowerTable
@@ -108,10 +105,18 @@ function ClockingTable({ device, totalPowerCallback }) {
               resources={powerTable}
             />
           </div>
-          <TableBase header={mainTableHeader}>
+          <TableBase
+            header={mainTableHeader}
+            disabled={device === null}
+            onClick={() => setModalOpen(true)}
+          >
             {
             clockingData.map((row, index) => (
               <tr key={row.description}>
+                <Actions
+                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                  onDeleteClick={() => deleteRow(index)}
+                />
                 <td>{row.description}</td>
                 <td>{GetText(row.source, sources)}</td>
                 <td>{row.port}</td>
@@ -124,10 +129,6 @@ function ClockingTable({ device, totalPowerCallback }) {
                   {fixed(row.consumption.percentage, 0)}
                   {' %'}
                 </td>
-                <Actions
-                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                  onDeleteClick={() => deleteRow(index)}
-                />
               </tr>
             ))
           }

--- a/src/components/Tables/ConnectivityTable.js
+++ b/src/components/Tables/ConnectivityTable.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FaPlus } from 'react-icons/fa6';
 import PowerTable from './PowerTable';
 import * as server from '../../utils/serverAPI';
 import { connectivityNames, loadActivity, findEvailableIndex } from '../../utils/cpu';
@@ -11,6 +10,7 @@ import {
 import { GetText, fixed } from '../../utils/common';
 import { publish } from '../../utils/events';
 import { useSocTotalPower } from '../../SOCTotalPowerProvider';
+import { ComponentLabel } from '../ComponentsLib';
 
 import '../style/ACPUTable.css';
 
@@ -77,8 +77,8 @@ function ConnectivityTable({ device }) {
     setAddButtonDisable(found === undefined);
   }, [endpoints]);
 
-  const header = ['Clock', 'Frequency', 'Endpoint', 'Activity', 'R/W',
-    'Toggle Rate', 'Bandwidth', 'Noc Power', '%', 'Action',
+  const header = ['Action', 'Clock', 'Frequency', 'Endpoint', 'Activity', 'R/W',
+    'Toggle Rate', 'Bandwidth', 'Noc Power', '%',
   ];
 
   function modifyRow(index, row) {
@@ -115,10 +115,7 @@ function ConnectivityTable({ device }) {
   return (
     <div className="acpu-container main-border">
       <div className="main-block">
-        <div className="layout-head">
-          <label>FPGA &gt; Connectivity</label>
-          <button type="button" disabled={addButtonDisable} className="plus-button" onClick={() => setModalOpen(true)}><FaPlus /></button>
-        </div>
+        <ComponentLabel name="Connectivity" />
         <div className="cpu-container">
           <div className="power-and-table-wrapper">
             <PowerTable
@@ -128,11 +125,19 @@ function ConnectivityTable({ device }) {
               resources={powerData}
               subHeader="Sub System"
             />
-            <TableBase header={header}>
+            <TableBase
+              header={header}
+              disabled={addButtonDisable}
+              onClick={() => setModalOpen(true)}
+            >
               {
               endpoints.map((row, index) => (
                 (row.data !== undefined && row.data.name !== '') && (
                 <tr key={row.ep}>
+                  <Actions
+                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                    onDeleteClick={() => deleteRow(index)}
+                  />
                   <td>{row.data.clock}</td>
                   <FrequencyCell val={row.data.consumption.clock_frequency} />
                   <td>{row.data.name}</td>
@@ -145,10 +150,6 @@ function ConnectivityTable({ device }) {
                     {fixed(row.data.consumption.percentage, 0)}
                     {' %'}
                   </td>
-                  <Actions
-                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                    onDeleteClick={() => deleteRow(index)}
-                  />
                 </tr>
                 )
               ))

--- a/src/components/Tables/DMATable.js
+++ b/src/components/Tables/DMATable.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FaPlus } from 'react-icons/fa6';
 import DMAModal from '../ModalWindows/DMAModal';
 import { source, loadActivity } from '../../utils/cpu';
 import PowerTable from './PowerTable';
@@ -10,6 +9,7 @@ import { PercentsCell, PowerCell, SelectionCell } from './TableCells';
 import { TableBase, Actions } from './TableBase';
 import { publish } from '../../utils/events';
 import { useSocTotalPower } from '../../SOCTotalPowerProvider';
+import { ComponentLabel } from '../ComponentsLib';
 
 import '../style/ComponentTable.css';
 
@@ -29,8 +29,8 @@ function DMATable({ device }) {
   const { updateTotalPower } = useSocTotalPower();
 
   const mainTableHeader = [
-    'Channel name', 'Source', 'Destination', 'Activity', 'R/W', 'Toggle Rate',
-    'Bandwidth', 'Block Power', '%', 'Action',
+    'Action', 'Channel name', 'Source', 'Destination', 'Activity', 'R/W', 'Toggle Rate',
+    'Bandwidth', 'Block Power', '%',
   ];
 
   React.useEffect(() => {
@@ -113,10 +113,7 @@ function DMATable({ device }) {
   return (
     <div className="component-table-head main-border">
       <div className="main-block">
-        <div className="layout-head">
-          <label>FPGA &gt; DMA</label>
-          <button type="button" disabled={addButtonDisable} className="plus-button" onClick={() => setModalOpen(true)}><FaPlus /></button>
-        </div>
+        <ComponentLabel name="DMA" />
         <div className="power-and-table-wrapper">
           <div className="power-table-wrapper">
             <PowerTable
@@ -127,11 +124,19 @@ function DMATable({ device }) {
               subHeader="Sub System"
             />
           </div>
-          <TableBase header={mainTableHeader}>
+          <TableBase
+            header={mainTableHeader}
+            disabled={addButtonDisable}
+            onClick={() => setModalOpen(true)}
+          >
             {
             dmaData.map((row, index) => (
               row.data.enable && (
                 <tr key={row.id}>
+                  <Actions
+                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                    onDeleteClick={() => deleteRow(row.id)}
+                  />
                   <td>{row.data.name}</td>
                   <SelectionCell val={row.data.source} values={source} />
                   <SelectionCell val={row.data.destination} values={source} />
@@ -144,10 +149,6 @@ function DMATable({ device }) {
                     {fixed(row.data.consumption.percentage, 0)}
                     {' %'}
                   </td>
-                  <Actions
-                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                    onDeleteClick={() => deleteRow(row.id)}
-                  />
                 </tr>
               )
             ))

--- a/src/components/Tables/DspTable.js
+++ b/src/components/Tables/DspTable.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FaPlus } from 'react-icons/fa6';
 import DspModal from '../ModalWindows/DspModal';
 import PowerTable from './PowerTable';
 import * as server from '../../utils/serverAPI';
@@ -7,6 +6,7 @@ import { fixed, GetText } from '../../utils/common';
 import { dspMode, pipelining } from '../../utils/dsp';
 import { PercentsCell, FrequencyCell, PowerCell } from './TableCells';
 import { TableBase, Actions } from './TableBase';
+import { ComponentLabel } from '../ComponentsLib';
 
 import '../style/ComponentTable.css';
 
@@ -80,18 +80,15 @@ function DspTable({ device, totalPowerCallback }) {
   ];
 
   const mainTableHeader = [
-    'Name/Hierarchy', 'XX', 'DSP Mode', { className: 'no-wrap', text: 'A-W' }, { className: 'no-wrap', text: 'B-W' },
+    'Action', 'Name/Hierarchy', 'XX', 'DSP Mode', { className: 'no-wrap', text: 'A-W' }, { className: 'no-wrap', text: 'B-W' },
     'Clock', 'Pipeline', 'T-Rate',
-    'Block Used', 'Clock Freq', 'O/P Sig Rate', 'Block Power', 'Intc. Power', '%', 'Action',
+    'Block Used', 'Clock Freq', 'O/P Sig Rate', 'Block Power', 'Intc. Power', '%',
   ];
 
   return (
     <div className="component-table-head main-border">
       <div className="main-block">
-        <div className="layout-head">
-          <label>FPGA &gt; DSP</label>
-          <button type="button" className="plus-button" onClick={() => setModalOpen(true)}><FaPlus /></button>
-        </div>
+        <ComponentLabel name="DSP" />
         <div className="power-and-table-wrapper">
           <div className="power-table-wrapper">
             <PowerTable
@@ -101,11 +98,19 @@ function DspTable({ device, totalPowerCallback }) {
               resources={powerTable}
             />
           </div>
-          <TableBase header={mainTableHeader}>
+          <TableBase
+            header={mainTableHeader}
+            disabled={device === null}
+            onClick={() => setModalOpen(true)}
+          >
             {
             dspData.map((row, index) => (
               // eslint-disable-next-line react/no-array-index-key
               <tr key={index}>
+                <Actions
+                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                  onDeleteClick={() => deleteRow(index)}
+                />
                 <td>{row.name}</td>
                 <td>{row.number_of_multipliers}</td>
                 <td>{GetText(row.dsp_mode, dspMode)}</td>
@@ -126,10 +131,6 @@ function DspTable({ device, totalPowerCallback }) {
                   {fixed(row.consumption.percentage, 0)}
                   {' %'}
                 </td>
-                <Actions
-                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                  onDeleteClick={() => deleteRow(index)}
-                />
               </tr>
             ))
           }

--- a/src/components/Tables/FleTable.js
+++ b/src/components/Tables/FleTable.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FaPlus } from 'react-icons/fa6';
 import FleModal from '../ModalWindows/FleModal';
 import glitchFactor from '../../utils/fle';
 import PowerTable from './PowerTable';
@@ -7,6 +6,7 @@ import * as server from '../../utils/serverAPI';
 import { fixed, GetText } from '../../utils/common';
 import { PercentsCell, FrequencyCell, PowerCell } from './TableCells';
 import { TableBase, Actions } from './TableBase';
+import { ComponentLabel } from '../ComponentsLib';
 
 import '../style/ComponentTable.css';
 
@@ -84,17 +84,14 @@ function FleTable({ device, totalPowerCallback }) {
   ];
 
   const mainTableHeader = [
-    'Name/Hierarchy', 'LUT6', 'FF/Latch', 'Clock', 'Toggle Rate', 'Glitch Factor', 'Clock Enable',
-    'Clock Freq', 'O/P Sig Rate', 'Block Power', 'Intc. Power', '%', 'Action',
+    'Action', 'Name/Hierarchy', 'LUT6', 'FF/Latch', 'Clock', 'Toggle Rate', 'Glitch Factor', 'Clock Enable',
+    'Clock Freq', 'O/P Sig Rate', 'Block Power', 'Intc. Power', '%',
   ];
 
   return (
     <div className="component-table-head main-border">
       <div className="main-block">
-        <div className="layout-head">
-          <label>FPGA &gt; FLE</label>
-          <button type="button" className="plus-button" onClick={() => setModalOpen(true)}><FaPlus /></button>
-        </div>
+        <ComponentLabel name="FLE" />
         <div className="power-and-table-wrapper">
           <div className="power-table-wrapper">
             <PowerTable
@@ -104,10 +101,18 @@ function FleTable({ device, totalPowerCallback }) {
               resources={powerTable}
             />
           </div>
-          <TableBase header={mainTableHeader}>
+          <TableBase
+            header={mainTableHeader}
+            disabled={device === null}
+            onClick={() => setModalOpen(true)}
+          >
             {
             fleData.map((row, index) => (
               <tr key={row.name}>
+                <Actions
+                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                  onDeleteClick={() => deleteRow(index)}
+                />
                 <td>{row.name}</td>
                 <td>{row.lut6}</td>
                 <td>{row.flip_flop}</td>
@@ -126,10 +131,6 @@ function FleTable({ device, totalPowerCallback }) {
                   {fixed(row.consumption.percentage, 0)}
                   {' %'}
                 </td>
-                <Actions
-                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                  onDeleteClick={() => deleteRow(index)}
-                />
               </tr>
             ))
           }

--- a/src/components/Tables/IOTable.js
+++ b/src/components/Tables/IOTable.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { FaPlus } from 'react-icons/fa6';
 import IOModal from '../ModalWindows/IOModal';
 import IOPowerTable from './IOPowerTable';
 import * as server from '../../utils/serverAPI';
 import { fixed } from '../../utils/common';
 import { PercentsCell, SelectionCell, PowerCell } from './TableCells';
 import { TableBase, Actions } from './TableBase';
+import { ComponentLabel } from '../ComponentsLib';
 
 import '../style/ComponentTable.css';
 import {
@@ -146,18 +146,15 @@ function IOTable({ device, totalPowerCallback }) {
   };
 
   const mainTableHeader = [
-    'RTL Port Name', 'Bus', 'Dir', 'IO Standard', 'Drive Strength', 'Slew Rate', 'Differential Termination', 'Data Type',
+    'Action', 'RTL Port Name', 'Bus', 'Dir', 'IO Standard', 'Drive Strength', 'Slew Rate', 'Differential Termination', 'Data Type',
     'Clock', 'Toggle Rate', 'Duty Cycle', 'Sync', 'Input En', 'Output En', 'Pullup / Pulldown', 'Bank Type', 'Bank #',
-    'VCCIO', 'Signal Rate', 'Block Power', 'Intc. Power', '%', 'Action',
+    'VCCIO', 'Signal Rate', 'Block Power', 'Intc. Power', '%',
   ];
 
   return (
     <div className="component-table-head main-border">
       <div className="main-block">
-        <div className="layout-head">
-          <label>FPGA &gt; IO</label>
-          <button type="button" className="plus-button" onClick={() => setModalOpen(true)}><FaPlus /></button>
-        </div>
+        <ComponentLabel name="IO" />
         <div className="power-and-table-wrapper">
           <div className="power-table-wrapper">
             <IOPowerTable
@@ -166,11 +163,19 @@ function IOTable({ device, totalPowerCallback }) {
               resources={powerTable !== null ? powerTable : defaultPowerData}
             />
           </div>
-          <TableBase header={mainTableHeader}>
+          <TableBase
+            header={mainTableHeader}
+            disabled={device === null}
+            onClick={() => setModalOpen(true)}
+          >
             {
             ioData.map((row, index) => (
               // eslint-disable-next-line react/no-array-index-key
               <tr key={index}>
+                <Actions
+                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                  onDeleteClick={() => deleteRow(index)}
+                />
                 <td>{row.name}</td>
                 <td>{row.bus_width}</td>
                 <SelectionCell val={row.direction} values={direction} />
@@ -199,10 +204,6 @@ function IOTable({ device, totalPowerCallback }) {
                   {fixed(row.consumption.percentage, 0)}
                   {' %'}
                 </td>
-                <Actions
-                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                  onDeleteClick={() => deleteRow(index)}
-                />
               </tr>
             ))
           }

--- a/src/components/Tables/MemoryTable.js
+++ b/src/components/Tables/MemoryTable.js
@@ -9,6 +9,7 @@ import { PowerCell, SelectionCell } from './TableCells';
 import { TableBase, Actions, Checkbox } from './TableBase';
 import { publish } from '../../utils/events';
 import { useSocTotalPower } from '../../SOCTotalPowerProvider';
+import { ComponentLabel } from '../ComponentsLib';
 
 import '../style/ComponentTable.css';
 
@@ -25,8 +26,8 @@ function MemoryTable({ device }) {
   const { updateTotalPower } = useSocTotalPower();
 
   const mainTableHeader = [
-    '', 'Memory', 'Usage', 'Memory Type', 'Data Rate', 'Width', 'R Bandwidth',
-    'W Bandwidth', 'Block Power', '%', 'Action',
+    '', 'Memory', 'Action', 'Usage', 'Memory Type', 'Data Rate', 'Width', 'R Bandwidth',
+    'W Bandwidth', 'Block Power', '%',
   ];
 
   React.useEffect(() => {
@@ -98,9 +99,7 @@ function MemoryTable({ device }) {
   return (
     <div className="component-table-head main-border">
       <div className="main-block">
-        <div className="layout-head">
-          <label>FPGA &gt; Memory</label>
-        </div>
+        <ComponentLabel name="Memory" />
         <div className="power-and-table-wrapper">
           <div className="power-table-wrapper">
             <PowerTable
@@ -111,7 +110,7 @@ function MemoryTable({ device }) {
               subHeader="Sub System"
             />
           </div>
-          <TableBase header={mainTableHeader}>
+          <TableBase header={mainTableHeader} hideAddBtn>
             {
             memoryData.map((row, index) => (
               row.data.enable !== undefined && (
@@ -126,6 +125,9 @@ function MemoryTable({ device }) {
                     />
                   </td>
                   <td>{row.data.name}</td>
+                  <Actions
+                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                  />
                   <SelectionCell val={row.data.usage} values={memory.usage} />
                   <SelectionCell val={row.data.memory_type} values={memory.memory_type} />
                   <td>{row.data.data_rate}</td>
@@ -137,9 +139,6 @@ function MemoryTable({ device }) {
                     {fixed(row.data.consumption.percentage, 0)}
                     {' %'}
                   </td>
-                  <Actions
-                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                  />
                 </tr>
               )
             ))

--- a/src/components/Tables/PeripheralsTable.js
+++ b/src/components/Tables/PeripheralsTable.js
@@ -6,6 +6,7 @@ import { PowerCell, SelectionCell } from './TableCells';
 import { TableBase, Actions, Checkbox } from './TableBase';
 import * as per from '../../utils/peripherals';
 import { useSocTotalPower } from '../../SOCTotalPowerProvider';
+import { ComponentLabel } from '../ComponentsLib';
 
 import '../style/ComponentTable.css';
 
@@ -81,7 +82,7 @@ function PeripheralsTable({ device }) {
   ]);
 
   const mainTableHeader = [
-    '', '', 'Usage', 'Performance', 'Bandwidth', 'Block Power', '%', 'Action',
+    '', '', 'Action', 'Usage', 'Performance', 'Bandwidth', 'Block Power', '%',
   ];
 
   function peripheralMatch(component, data, url) {
@@ -159,10 +160,8 @@ function PeripheralsTable({ device }) {
   return (
     <div className="component-table-head main-border">
       <div className="main-block">
-        <div className="layout-head">
-          <label>FPGA &gt; Peripherals</label>
-        </div>
-        <TableBase header={mainTableHeader}>
+        <ComponentLabel name="Peripherals" />
+        <TableBase header={mainTableHeader} hideAddBtn>
           {
             peripherals.map((row, index) => row.data.map((i, idx) => (
               i.data !== undefined && (
@@ -178,6 +177,12 @@ function PeripheralsTable({ device }) {
                   />
                 </td>
                 <td className="innerHeader">{i.data.name}</td>
+                <Actions
+                  onEditClick={() => {
+                    setEditIndex({ main: index, inner: idx });
+                    setModalOpen(true);
+                  }}
+                />
                 <SelectionCell val={i.data.usage} values={row.usage} />
                 <SelectionCell val={per.getPerformance(i.data)} values={row.performance} />
                 <td>
@@ -189,12 +194,6 @@ function PeripheralsTable({ device }) {
                   {fixed(parseFloat(i.data.consumption.percentage), 0)}
                   {' %'}
                 </td>
-                <Actions
-                  onEditClick={() => {
-                    setEditIndex({ main: index, inner: idx });
-                    setModalOpen(true);
-                  }}
-                />
               </tr>
               )
             )))

--- a/src/components/Tables/PowerSummaryTable.js
+++ b/src/components/Tables/PowerSummaryTable.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { PowerCell } from './TableCells';
-import { fixed, State } from '../../utils/common';
+import { fixed } from '../../utils/common';
+import { State } from '../ComponentsLib';
 
 import '../style/PowerSummaryTable.css';
 

--- a/src/components/Tables/PowerSummaryTable.js
+++ b/src/components/Tables/PowerSummaryTable.js
@@ -37,8 +37,7 @@ function PowerSummaryTable({
       <div className="pst-bottom">
         <div className="pst-bottom-progress">
           <label htmlFor="progress-bar">
-            {' '}
-            {percent}
+            {fixed(percent, 0)}
             %
           </label>
           <progress id="progress-bar" value={percent} max={100} />

--- a/src/components/Tables/TableBase.js
+++ b/src/components/Tables/TableBase.js
@@ -41,10 +41,11 @@ export function TableBase({
   return (
     <div className="table-wrapper">
       {!hideAddBtn && <AddButton disabled={disabled} onClick={onClick} />}
-      <table className="table-style main-border">
-        <thead>
-          <tr>
-            {
+      <div className="main-border">
+        <table className="table-style">
+          <thead>
+            <tr>
+              {
               header.map((item, index) => {
                 if (item.className) {
                   // eslint-disable-next-line react/no-array-index-key
@@ -54,14 +55,15 @@ export function TableBase({
                 return <th key={index}>{item}</th>;
               })
             }
-          </tr>
-        </thead>
-        <tbody>
-          {
+            </tr>
+          </thead>
+          <tbody>
+            {
             children
           }
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/components/Tables/TableBase.js
+++ b/src/components/Tables/TableBase.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BsFillTrashFill } from 'react-icons/bs';
 import { PiNotePencil } from 'react-icons/pi';
-import { FaPlus } from 'react-icons/fa6';
+import { AddButton } from '../ComponentsLib';
 
 import '../style/ComponentTable.css';
 
@@ -35,9 +35,12 @@ export function Checkbox({
   );
 }
 
-export function TableBase({ header, children }) {
+export function TableBase({
+  header, disabled, onClick, hideAddBtn = false, children,
+}) {
   return (
     <div className="table-wrapper">
+      {!hideAddBtn && <AddButton disabled={disabled} onClick={onClick} />}
       <table className="table-style main-border">
         <thead>
           <tr>
@@ -59,32 +62,6 @@ export function TableBase({ header, children }) {
           }
         </tbody>
       </table>
-    </div>
-  );
-}
-
-export function TableBaseWrapper({
-  title, content, powerTable, modalContent,
-}) {
-  const [modalOpen, setModalOpen] = React.useState(false);
-  return (
-    <div className="component-table-head main-border">
-      <div className="main-block">
-        <div className="layout-head">
-          <label htmlFor="plus-button">{title}</label>
-          <button name="plus-button" aria-label="Add" type="button" className="plus-button" onClick={setModalOpen(true)}><FaPlus /></button>
-        </div>
-        {
-          content
-        }
-        {modalOpen
-          && (modalContent)}
-      </div>
-      <div className="power-table-wrapper">
-        {
-          powerTable
-        }
-      </div>
     </div>
   );
 }

--- a/src/components/TitleComponent.js
+++ b/src/components/TitleComponent.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { fixed } from '../utils/common';
+import { useSocTotalPower } from '../SOCTotalPowerProvider';
 
 import './style/TitleComponent.css';
 
 function TitleComponent({
   title, staticText, dynamicPower, staticPower,
 }) {
+  const { calcPercents } = useSocTotalPower();
   function getTotal() {
     return dynamicPower + staticPower;
   }
@@ -19,7 +21,10 @@ function TitleComponent({
           {fixed(getTotal())}
           {' W'}
         </div>
-        <div className="label-value title-comp-total-text">0 %</div>
+        <div className="label-value title-comp-total-text">
+          {fixed(calcPercents(getTotal()), 0)}
+          {' %'}
+        </div>
         <div className="grayed-text">Dynamic</div>
         <div className="grayed-text label-value">
           {fixed(dynamicPower)}

--- a/src/components/TypicalWorstComponent.js
+++ b/src/components/TypicalWorstComponent.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { AiFillThunderbolt } from 'react-icons/ai';
-import { fixed, State } from '../utils/common';
+import { fixed } from '../utils/common';
 import { useSocTotalPower } from '../SOCTotalPowerProvider';
+import { State } from './ComponentsLib';
 
 import './style/TypicalWorstComponent.css';
 

--- a/src/components/TypicalWorstComponent.js
+++ b/src/components/TypicalWorstComponent.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AiFillThunderbolt } from 'react-icons/ai';
 import { fixed, State } from '../utils/common';
+import { useSocTotalPower } from '../SOCTotalPowerProvider';
 
 import './style/TypicalWorstComponent.css';
 
@@ -37,10 +38,23 @@ const warnWorst = 40; // TBD
 const errorWorst = 10; // TBD
 
 function TypicalWorstComponent() {
+  const { thermalData } = useSocTotalPower();
   return (
     <div className="twc-main main-border">
-      <Column title="Typical" power={20} warnPow={warnTypical} errPow={errorTypical} temp={25} />
-      <Column title="Worst case" power={20} warnPow={warnWorst} errPow={errorWorst} temp={85} />
+      <Column
+        title="Typical"
+        power={thermalData.typical.total_power}
+        warnPow={warnTypical}
+        errPow={errorTypical}
+        temp={thermalData.typical.thermal}
+      />
+      <Column
+        title="Worst case"
+        power={thermalData.worsecase.total_power}
+        warnPow={warnWorst}
+        errPow={errorWorst}
+        temp={thermalData.worsecase.thermal}
+      />
     </div>
   );
 }

--- a/src/components/style/ACPUTable.css
+++ b/src/components/style/ACPUTable.css
@@ -1,5 +1,6 @@
 .acpu-container {
-    padding: 10px;
+    padding: 6px;
+    padding-top: 0;
     display: inline-flex;
     gap: 10px;
 }

--- a/src/components/style/ComponentTable.css
+++ b/src/components/style/ComponentTable.css
@@ -3,11 +3,11 @@
 }
 
 .table-style {
-    display: block;
     overflow: hidden;
     table-layout: auto;
     border-collapse: collapse;
-    max-width: 100%;
+    width: 100%;
+    border-radius: 8px;
 }
 
 .table-style thead {
@@ -50,10 +50,9 @@
     padding-top: 0;
     display: inline-flex;
     gap: 10px;
+    width: 100%;
 }
 
-/* .main-block {
-    display: flex;
-    flex-direction: row;
-    column-gap: 10px;
-} */
+.main-block {
+    width: 100%;
+}

--- a/src/components/style/ComponentTable.css
+++ b/src/components/style/ComponentTable.css
@@ -45,19 +45,15 @@
     color: #2e65f3;
 }
 
-.layout-head {
-    display: flex;
-    padding: 0.4rem;
-    gap: 10px;
-}
-
 .component-table-head {
-    padding: 10px;
+    padding: 6px;
+    padding-top: 0;
     display: inline-flex;
     gap: 10px;
 }
 
-.plus-button {
-    justify-content: center;
-    align-items: center;
-}
+/* .main-block {
+    display: flex;
+    flex-direction: row;
+    column-gap: 10px;
+} */

--- a/src/components/style/ComponentsLib.css
+++ b/src/components/style/ComponentsLib.css
@@ -1,0 +1,55 @@
+.layout-head {
+    display: flex;
+    padding: 6px;
+    column-gap: 5px;
+    /* border: 1px solid black; */
+}
+
+.component-label-text-center {
+    display: flex;
+    padding: 0;
+    justify-content: center;
+    align-items: center;
+    padding-top: 1px;
+    /* fix unknown offset */
+}
+
+.component-label {
+    border-radius: 10px;
+    background-color: #3385FF;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 3px;
+    padding-bottom: 2px;
+    color: white;
+}
+
+.button {
+    font-size: 12px;
+    font-weight: bold;
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 10px 0 8px;
+    border: none;
+    text-decoration: none;
+    color: #007bff;
+    line-height: 1;
+    background-color: #e7e3e3;
+    border-radius: 10px;
+    cursor: pointer;
+}
+
+.button:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.icon-container {
+    padding-top: 2px;
+    align-items: center;
+    align-content: center;
+}
+
+.icon {
+    transform: scale(1.2);
+}

--- a/src/components/style/SOCTable.css
+++ b/src/components/style/SOCTable.css
@@ -4,6 +4,7 @@
     flex-direction: column;
     row-gap: 8px;
     background-color: #f2f2f2;
+    width: 100%;
 }
 
 .top-l2-col1-row1 {

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,6 @@
 .rpe-head {
+    display: flex;
+    flex-direction: column;
     font-size: 14px;
 }
 
@@ -6,11 +8,13 @@
     display: flex;
     flex-direction: row;
     column-gap: 10px;
+    min-width: fit-content;
 }
 
 .top-container {
     display: flex;
     flex-direction: column;
+    width: 100%;
 }
 
 .top-l1 {
@@ -36,8 +40,10 @@
     flex-grow: 1;
 }
 
-.hspacer {
-    min-height: 8px;
+.table-container {
+    display: flex;
+    padding-top: 8px;
+    min-width: fit-content;
 }
 
 .power-tables {
@@ -122,6 +128,7 @@
     display: flex;
     flex-direction: row;
     column-gap: 10px;
+    width: 100%;
 }
 
 :root {

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export const Table = {
   Clocking: 0,
   FLE: 1,
@@ -39,21 +37,4 @@ export const FieldType = {
 
 export function percentage(val, sum) {
   return fixed((val / sum) * 100, 0);
-}
-
-export function State({
-  refValue, warn, err, baseClass = 'clickable', children,
-}) {
-  const buildClassName = React.useCallback(() => {
-    let base = baseClass;
-    if (refValue >= err) base += ' error';
-    else if (refValue >= warn) base += ' warning';
-    else base += ' normal';
-    return base;
-  }, [refValue, warn, err, baseClass]);
-  return (
-    <div className={buildClassName()}>
-      {children}
-    </div>
-  );
 }


### PR DESCRIPTION
Update:
* Fetch thermal data from backend
* Show this data in the Typical/Worst case table
* Calculates percentage for FPGA/SOC total power
* Update labels for components table FPGA > <component name>
* Update Add button
* Move Actions column at the begging of the table.
* Update horizontal layout 
  * Keep two right panels always right
  *  Expand main table in case screen bigger then need
  * Bottom panel width sync with main width ( there is still issue when screen become small, bottom panel also become small )

Note. SOC total power percentage > 100% means something wrong with backend calculation. 

![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/80536720-929d-4718-ab67-b61f12ba689d)

![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/7ff24a11-dbd8-4554-ac05-00db7b124939)

![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/da69be91-0e0c-4961-ad72-3aed76bd40d3)

![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/26cef92f-6e07-4429-a79d-c9948bf430d5)

![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/3a2ea809-9d34-4f8d-99a8-d6b6c5db7991)

