### PR TITLE
Fixed window issue with backend processes

### DIFF
--- a/cleanup.js
+++ b/cleanup.js
@@ -1,0 +1,12 @@
+const isWindows = process.platform === 'win32';
+
+const kill = (process) => {
+  if (isWindows) {
+    const kill = require('tree-kill');
+    kill(process.pid);
+  } else {
+    process.kill('SIGINT');
+  }
+};
+
+module.exports = { kill };

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const Store = require('electron-store');
 const log = require('electron-log');
 const config = require('./rpe.config.json');
+const { kill } = require('./cleanup');
 
 const logFormat = '[{h}:{i}:{s}.{ms}] [{level}] {text}';
 log.transports.console.format = logFormat;
@@ -179,6 +180,6 @@ app.whenReady().then(() => {
 });
 
 app.on('window-all-closed', () => {
-  serverProcess.kill('SIGINT');
+  kill(serverProcess);
   if (process.platform !== 'darwin') app.quit();
 });

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
       "preload.js",
       "rpe.config.json",
       "node_modules/**/*",
-      "package.json"
+      "package.json",
+      "cleanup.js"
     ],
     "directories": {
       "buildResources": "resources"
@@ -106,7 +107,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",
-    "react-switch": "^7.0.0"
+    "react-switch": "^7.0.0",
+    "tree-kill": "^1.2.2"
   },
   "files": [
     "build/**/*"


### PR DESCRIPTION
Use `tree-kill` package for killing processes on Windows. For linux this doesn't work since command `ps -o pid --no-headers --ppid PID` that is run under the hood returns nothing. 