### PR TITLE
Layout update

### DIFF
--- a/main.js
+++ b/main.js
@@ -137,8 +137,8 @@ const startFlaskServer = () => {
 let serverProcess = null;
 const createWindow = () => {
   mainWindow = new BrowserWindow({
-    width: 1200,
-    height: 700,
+    width: 1400,
+    height: 800,
     webPreferences: {
       preload: path.join(app.getAppPath(), 'preload.js'),
       nodeIntegration: true,

--- a/src/App.js
+++ b/src/App.js
@@ -226,7 +226,7 @@ function App() {
           <SOCSummaryComponent device={device} />
         </div>
       </div>
-      <div className="table-container">
+      <div className="table-container main-border">
         {
         openedTable === Table.Clocking
         && <ClockingTable device={device} totalPowerCallback={setClockingPower} />

--- a/src/App.js
+++ b/src/App.js
@@ -139,8 +139,8 @@ function App() {
 
   return (
     <div className="rpe-head">
-      <div className="app-main-container">
-        <div className="top-container main-border">
+      <div className="top-row-container">
+        <div className="main-table-container main-border">
           <div className="top-l1 main-bottom-border" onClick={() => setOpenedTable(Table.Summary)}>
             <DeviceList
               devices={devices}

--- a/src/components/ModalWindows/ABCPUModal.js
+++ b/src/components/ModalWindows/ABCPUModal.js
@@ -5,10 +5,11 @@ import { FieldType } from '../../utils/common';
 import ModalWindow from './ModalWindow';
 
 function ABCPUModal({
-  closeModal, onSubmit, defaultValue, endpoints,
+  closeModal, onSubmit, defaultValue, endpoints, title,
 }) {
   return (
     <ModalWindow
+      title={title}
       closeModal={closeModal}
       onSubmit={onSubmit}
       defaultValue={defaultValue}

--- a/src/components/ModalWindows/BramModal.js
+++ b/src/components/ModalWindows/BramModal.js
@@ -4,9 +4,12 @@ import { FieldType } from '../../utils/common';
 
 import ModalWindow from './ModalWindow';
 
-function BramModal({ closeModal, onSubmit, defaultValue }) {
+function BramModal({
+  closeModal, onSubmit, defaultValue, title,
+}) {
   return (
     <ModalWindow
+      title={title}
       closeModal={closeModal}
       onSubmit={onSubmit}
       defaultValue={defaultValue}

--- a/src/components/ModalWindows/ClockingModal.js
+++ b/src/components/ModalWindows/ClockingModal.js
@@ -3,9 +3,13 @@ import { sources, states } from '../../utils/clocking';
 import { FieldType } from '../../utils/common';
 import ModalWindow from './ModalWindow';
 
-function ClockingModal({ closeModal, onSubmit, defaultValue }) {
+function ClockingModal({
+  closeModal, onSubmit, defaultValue, title, isModalOpen,
+}) {
   return (
     <ModalWindow
+      title={title}
+      isModalOpen={isModalOpen}
       closeModal={closeModal}
       onSubmit={onSubmit}
       defaultValue={defaultValue}

--- a/src/components/ModalWindows/ConnectivityModal.js
+++ b/src/components/ModalWindows/ConnectivityModal.js
@@ -5,10 +5,11 @@ import { FieldType } from '../../utils/common';
 import ModalWindow from './ModalWindow';
 
 function ConnectivityModal({
-  closeModal, onSubmit, defaultValue,
+  closeModal, onSubmit, defaultValue, title,
 }) {
   return (
     <ModalWindow
+      title={title}
       closeModal={closeModal}
       onSubmit={onSubmit}
       defaultValue={defaultValue}

--- a/src/components/ModalWindows/DMAModal.js
+++ b/src/components/ModalWindows/DMAModal.js
@@ -4,9 +4,12 @@ import { source, loadActivity } from '../../utils/cpu';
 import { FieldType } from '../../utils/common';
 import ModalWindow from './ModalWindow';
 
-function DMAModal({ closeModal, onSubmit, defaultValue }) {
+function DMAModal({
+  closeModal, onSubmit, defaultValue, title,
+}) {
   return (
     <ModalWindow
+      title={title}
       closeModal={closeModal}
       onSubmit={onSubmit}
       defaultValue={defaultValue}

--- a/src/components/ModalWindows/DspModal.js
+++ b/src/components/ModalWindows/DspModal.js
@@ -4,9 +4,12 @@ import { FieldType } from '../../utils/common';
 
 import ModalWindow from './ModalWindow';
 
-function DspModal({ closeModal, onSubmit, defaultValue }) {
+function DspModal({
+  closeModal, onSubmit, defaultValue, title,
+}) {
   return (
     <ModalWindow
+      title={title}
       closeModal={closeModal}
       onSubmit={onSubmit}
       defaultValue={defaultValue}

--- a/src/components/ModalWindows/FleModal.js
+++ b/src/components/ModalWindows/FleModal.js
@@ -3,9 +3,12 @@ import glitchFactor from '../../utils/fle';
 import { FieldType } from '../../utils/common';
 import ModalWindow from './ModalWindow';
 
-function FleModal({ closeModal, onSubmit, defaultValue }) {
+function FleModal({
+  closeModal, onSubmit, defaultValue, title,
+}) {
   return (
     <ModalWindow
+      title={title}
       closeModal={closeModal}
       onSubmit={onSubmit}
       defaultValue={defaultValue}

--- a/src/components/ModalWindows/IOModal.js
+++ b/src/components/ModalWindows/IOModal.js
@@ -12,9 +12,12 @@ import {
 import { FieldType } from '../../utils/common';
 import ModalWindow from './ModalWindow';
 
-function IOModal({ closeModal, onSubmit, defaultValue }) {
+function IOModal({
+  closeModal, onSubmit, defaultValue, title,
+}) {
   return (
     <ModalWindow
+      title={title}
       closeModal={closeModal}
       onSubmit={onSubmit}
       defaultValue={defaultValue}

--- a/src/components/ModalWindows/ModalWindow.js
+++ b/src/components/ModalWindows/ModalWindow.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Modal } from 'antd';
 
 import { FieldType } from '../../utils/common';
 
@@ -11,28 +12,6 @@ function ModalWindow({
   const handleChange = (name, val) => {
     setFormState({ ...formState, [name]: val });
   };
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    onSubmit(formState);
-    closeModal();
-  };
-
-  const handleKeyPress = React.useCallback((event) => {
-    if (event.key === 'Escape') {
-      closeModal();
-    }
-  }, [closeModal]);
-
-  React.useEffect(() => {
-    // attach the event listener
-    document.addEventListener('keydown', handleKeyPress);
-
-    // remove the event listener
-    return () => {
-      document.removeEventListener('keydown', handleKeyPress);
-    };
-  }, [handleKeyPress]);
 
   function generateField(item) {
     if (item.fieldType === FieldType.textarea) {
@@ -90,44 +69,40 @@ function ModalWindow({
     );
   }
 
+  const handleOk = () => {
+    onSubmit(formState);
+    closeModal();
+  };
+
   return (
-    <div
-      className="modal-container"
-      onClick={(e) => {
-        if (e.target.className === 'modal-container') closeModal();
-      }}
+    <Modal
+      title={title}
+      open
+      onOk={handleOk}
+      onCancel={closeModal}
     >
       <div className="modal">
         <form>
-          {title
-            && (
-              <div className="form-group">
-                <label id="form-group-header">{title}</label>
-              </div>
-            )}
           {
-            fields.map((item) => {
-              if (Object.prototype.hasOwnProperty.call(item, 'internal')) {
-                return (
-                  <div key={item.id} className="form-group">
-                    <fieldset>
-                      <legend>{item.text}</legend>
-                      {
-                        item.internal.map((i) => generateField(i))
-                      }
-                    </fieldset>
-                  </div>
-                );
-              }
-              return generateField(item);
-            })
-          }
-          <button type="submit" className="btn" onClick={handleSubmit}>
-            Submit
-          </button>
+          fields.map((item) => {
+            if (Object.prototype.hasOwnProperty.call(item, 'internal')) {
+              return (
+                <div key={item.id} className="form-group">
+                  <fieldset>
+                    <legend>{item.text}</legend>
+                    {
+                      item.internal.map((i) => generateField(i))
+                    }
+                  </fieldset>
+                </div>
+              );
+            }
+            return generateField(item);
+          })
+        }
         </form>
       </div>
-    </div>
+    </Modal>
   );
 }
 

--- a/src/components/Tables/ACPUTable.js
+++ b/src/components/Tables/ACPUTable.js
@@ -128,9 +128,10 @@ function ACPUTable({ device }) {
   };
 
   const powerHeader = ['Power', '%'];
+  const title = 'ACPU';
   return (
     <div className="component-table-head">
-      <ComponentLabel name="ACPU" />
+      <ComponentLabel name={title} />
       <div className="cpu-container">
         <PowerTable
           title="ACPU power"
@@ -180,9 +181,9 @@ function ACPUTable({ device }) {
             ))
           }
         </TableBase>
-        {modalOpen
-        && (
+        {modalOpen && (
           <ABCPUModal
+            title={title}
             closeModal={() => {
               setModalOpen(false);
               setEditIndex(null);

--- a/src/components/Tables/ACPUTable.js
+++ b/src/components/Tables/ACPUTable.js
@@ -130,82 +130,80 @@ function ACPUTable({ device }) {
   const powerHeader = ['Power', '%'];
   return (
     <div className="component-table-head">
-      <div className="main-block">
-        <ComponentLabel name="ACPU" />
-        <div className="cpu-container">
-          <PowerTable
-            title="ACPU power"
-            total={null}
-            resourcesHeaders={powerHeader}
-            resources={powerData}
-            subHeader="Sub System"
-          />
-          <div className="acpu-group-container">
-            <div className="acpu-group">
-              <label>ACPU name</label>
-              <input type="text" onChange={(e) => handleChange('name', e.target.value)} value={acpuData.name} />
-            </div>
-            <div className="acpu-group">
-              <label>Frequency</label>
-              <input type="number" min={0} step={1} onChange={(e) => handleChange('frequency', e.target.value)} value={acpuData.frequency} />
-            </div>
-            <div className="acpu-group">
-              <label>Load</label>
-              <select type="text" value={acpuData.load} onChange={(e) => handleChange('load', parseInt(e.target.value, 10))}>
-                {
+      <ComponentLabel name="ACPU" />
+      <div className="cpu-container">
+        <PowerTable
+          title="ACPU power"
+          total={null}
+          resourcesHeaders={powerHeader}
+          resources={powerData}
+          subHeader="Sub System"
+        />
+        <div className="acpu-group-container">
+          <div className="acpu-group">
+            <label>ACPU name</label>
+            <input type="text" onChange={(e) => handleChange('name', e.target.value)} value={acpuData.name} />
+          </div>
+          <div className="acpu-group">
+            <label>Frequency</label>
+            <input type="number" min={0} step={1} onChange={(e) => handleChange('frequency', e.target.value)} value={acpuData.frequency} />
+          </div>
+          <div className="acpu-group">
+            <label>Load</label>
+            <select type="text" value={acpuData.load} onChange={(e) => handleChange('load', parseInt(e.target.value, 10))}>
+              {
                   loadActivity.map((it) => (
                     <option key={it.id} value={it.id}>{it.text}</option>
                   ))
                 }
-              </select>
-            </div>
+            </select>
           </div>
-          <TableBase header={header} disabled={addButtonDisable} onClick={() => setModalOpen(true)}>
-            {
-              endpoints.map((row, index) => (
-                (row.data !== undefined && row.data.name !== '')
-                && (
-                <tr key={row.ep}>
-                  <Actions
-                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                    onDeleteClick={() => deleteRow(index)}
-                  />
-                  <td>{row.data.name}</td>
-                  <SelectionCell val={row.data.activity} values={loadActivity} />
-                  <PercentsCell val={row.data.read_write_rate} />
-                  <PercentsCell val={row.data.toggle_rate} precition={1} />
-                  <PowerCell val={row.data.consumption.calculated_bandwidth} />
-                  <PowerCell val={row.data.consumption.noc_power} />
-                </tr>
-                )
-              ))
-            }
-          </TableBase>
-          {modalOpen
-            && (
-              <ABCPUModal
-                closeModal={() => {
-                  setModalOpen(false);
-                  setEditIndex(null);
-                }}
-                onSubmit={handleSubmit}
-                defaultValue={(editIndex !== null && {
-                  name: acpuNames.indexOf(acpuNames.find(
-                    (elem) => elem.text === endpoints[editIndex].data.name,
-                  )),
-                  activity: endpoints[editIndex].data.activity,
-                  read_write_rate: endpoints[editIndex].data.read_write_rate,
-                  toggle_rate: endpoints[editIndex].data.toggle_rate,
-                }) || {
-                  name: 0,
-                  activity: 0,
-                  read_write_rate: 0.5,
-                  toggle_rate: 0.125,
-                }}
-                endpoints={acpuNames}
-              />
-            )}
         </div>
+        <TableBase header={header} disabled={addButtonDisable} onClick={() => setModalOpen(true)}>
+          {
+            endpoints.map((row, index) => (
+              (row.data !== undefined && row.data.name !== '')
+              && (
+              <tr key={row.ep}>
+                <Actions
+                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                  onDeleteClick={() => deleteRow(index)}
+                />
+                <td>{row.data.name}</td>
+                <SelectionCell val={row.data.activity} values={loadActivity} />
+                <PercentsCell val={row.data.read_write_rate} />
+                <PercentsCell val={row.data.toggle_rate} precition={1} />
+                <PowerCell val={row.data.consumption.calculated_bandwidth} />
+                <PowerCell val={row.data.consumption.noc_power} />
+              </tr>
+              )
+            ))
+          }
+        </TableBase>
+        {modalOpen
+        && (
+          <ABCPUModal
+            closeModal={() => {
+              setModalOpen(false);
+              setEditIndex(null);
+            }}
+            onSubmit={handleSubmit}
+            defaultValue={(editIndex !== null && {
+              name: acpuNames.indexOf(acpuNames.find(
+                (elem) => elem.text === endpoints[editIndex].data.name,
+              )),
+              activity: endpoints[editIndex].data.activity,
+              read_write_rate: endpoints[editIndex].data.read_write_rate,
+              toggle_rate: endpoints[editIndex].data.toggle_rate,
+            }) || {
+              name: 0,
+              activity: 0,
+              read_write_rate: 0.5,
+              toggle_rate: 0.125,
+            }}
+            endpoints={acpuNames}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/Tables/ACPUTable.js
+++ b/src/components/Tables/ACPUTable.js
@@ -129,7 +129,7 @@ function ACPUTable({ device }) {
 
   const powerHeader = ['Power', '%'];
   return (
-    <div className="acpu-container main-border">
+    <div className="component-table-head">
       <div className="main-block">
         <ComponentLabel name="ACPU" />
         <div className="cpu-container">

--- a/src/components/Tables/BCPUTable.js
+++ b/src/components/Tables/BCPUTable.js
@@ -142,9 +142,10 @@ function BCPUTable({ device }) {
   }, [bcpuData, device, updateTotalPower]);
 
   const powerHeader = ['Power', '%'];
+  const title = 'BCPU';
   return (
     <div className="component-table-head">
-      <ComponentLabel name="BCPU" />
+      <ComponentLabel name={title} />
       <div className="cpu-container">
         <PowerTable
           title="BCPU power"
@@ -202,9 +203,9 @@ function BCPUTable({ device }) {
             ))
           }
         </TableBase>
-        {modalOpen
-        && (
+        {modalOpen && (
           <ABCPUModal
+            title={title}
             closeModal={() => {
               setModalOpen(false);
               setEditIndex(null);

--- a/src/components/Tables/BCPUTable.js
+++ b/src/components/Tables/BCPUTable.js
@@ -143,7 +143,7 @@ function BCPUTable({ device }) {
 
   const powerHeader = ['Power', '%'];
   return (
-    <div className="acpu-container main-border">
+    <div className="component-table-head">
       <div className="main-block">
         <ComponentLabel name="BCPU" />
         <div className="cpu-container">

--- a/src/components/Tables/BCPUTable.js
+++ b/src/components/Tables/BCPUTable.js
@@ -144,90 +144,88 @@ function BCPUTable({ device }) {
   const powerHeader = ['Power', '%'];
   return (
     <div className="component-table-head">
-      <div className="main-block">
-        <ComponentLabel name="BCPU" />
-        <div className="cpu-container">
-          <PowerTable
-            title="BCPU power"
-            total={null}
-            resourcesHeaders={powerHeader}
-            resources={powerData}
-            subHeader="Sub System"
-          />
-          <div className="acpu-group-container">
-            <div className="acpu-group">
-              <label>BCPU name</label>
-              <input type="text" onChange={(e) => handleChange('name', e.target.value)} value={bcpuData.name} />
-            </div>
-            <div className="acpu-group">
-              <Checkbox
-                isChecked={bcpuData.encryption_used}
-                label="Encryption"
-                checkHandler={encryptionHandler}
-                id="encryption"
-              />
-            </div>
-            <div className="acpu-group">
-              <label>Boot Mode</label>
-              <input type="text" value={bootMode} disabled />
-            </div>
-            <div className="acpu-group">
-              <label>Clock</label>
-              <select type="text" value={bcpuData.clock} onChange={(e) => handleChange('clock', parseInt(e.target.value, 10))}>
-                {
+      <ComponentLabel name="BCPU" />
+      <div className="cpu-container">
+        <PowerTable
+          title="BCPU power"
+          total={null}
+          resourcesHeaders={powerHeader}
+          resources={powerData}
+          subHeader="Sub System"
+        />
+        <div className="acpu-group-container">
+          <div className="acpu-group">
+            <label>BCPU name</label>
+            <input type="text" onChange={(e) => handleChange('name', e.target.value)} value={bcpuData.name} />
+          </div>
+          <div className="acpu-group">
+            <Checkbox
+              isChecked={bcpuData.encryption_used}
+              label="Encryption"
+              checkHandler={encryptionHandler}
+              id="encryption"
+            />
+          </div>
+          <div className="acpu-group">
+            <label>Boot Mode</label>
+            <input type="text" value={bootMode} disabled />
+          </div>
+          <div className="acpu-group">
+            <label>Clock</label>
+            <select type="text" value={bcpuData.clock} onChange={(e) => handleChange('clock', parseInt(e.target.value, 10))}>
+              {
                   clock.map((it) => (
                     <option key={it.id} value={it.id}>{it.text}</option>
                   ))
                 }
-              </select>
-            </div>
+            </select>
           </div>
-          <TableBase header={header} disabled={addButtonDisable} onClick={() => setModalOpen(true)}>
-            {
-              endpoints.map((row, index) => (
-                (row.data !== undefined && row.data.name !== '')
-                && (
-                <tr key={row.ep}>
-                  <Actions
-                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                    onDeleteClick={() => deleteRow(index)}
-                  />
-                  <td>{row.data.name}</td>
-                  <SelectionCell val={row.data.activity} values={loadActivity} />
-                  <PercentsCell val={row.data.read_write_rate} />
-                  <PercentsCell val={row.data.toggle_rate} precition={1} />
-                  <PowerCell val={row.data.consumption.calculated_bandwidth} />
-                  <PowerCell val={row.data.consumption.noc_power} />
-                </tr>
-                )
-              ))
-            }
-          </TableBase>
-          {modalOpen
-            && (
-              <ABCPUModal
-                closeModal={() => {
-                  setModalOpen(false);
-                  setEditIndex(null);
-                }}
-                onSubmit={handleSubmit}
-                defaultValue={(editIndex !== null && {
-                  name: bcpuNames.indexOf(bcpuNames.find(
-                    (elem) => elem.text === endpoints[editIndex].data.name,
-                  )),
-                  activity: endpoints[editIndex].data.activity,
-                  read_write_rate: endpoints[editIndex].data.read_write_rate,
-                  toggle_rate: endpoints[editIndex].data.toggle_rate,
-                }) || {
-                  name: 0,
-                  activity: 0,
-                  read_write_rate: 0.5,
-                  toggle_rate: 0.125,
-                }}
-                endpoints={bcpuNames}
-              />
-            )}
         </div>
+        <TableBase header={header} disabled={addButtonDisable} onClick={() => setModalOpen(true)}>
+          {
+            endpoints.map((row, index) => (
+              (row.data !== undefined && row.data.name !== '')
+              && (
+              <tr key={row.ep}>
+                <Actions
+                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                  onDeleteClick={() => deleteRow(index)}
+                />
+                <td>{row.data.name}</td>
+                <SelectionCell val={row.data.activity} values={loadActivity} />
+                <PercentsCell val={row.data.read_write_rate} />
+                <PercentsCell val={row.data.toggle_rate} precition={1} />
+                <PowerCell val={row.data.consumption.calculated_bandwidth} />
+                <PowerCell val={row.data.consumption.noc_power} />
+              </tr>
+              )
+            ))
+          }
+        </TableBase>
+        {modalOpen
+        && (
+          <ABCPUModal
+            closeModal={() => {
+              setModalOpen(false);
+              setEditIndex(null);
+            }}
+            onSubmit={handleSubmit}
+            defaultValue={(editIndex !== null && {
+              name: bcpuNames.indexOf(bcpuNames.find(
+                (elem) => elem.text === endpoints[editIndex].data.name,
+              )),
+              activity: endpoints[editIndex].data.activity,
+              read_write_rate: endpoints[editIndex].data.read_write_rate,
+              toggle_rate: endpoints[editIndex].data.toggle_rate,
+            }) || {
+              name: 0,
+              activity: 0,
+              read_write_rate: 0.5,
+              toggle_rate: 0.125,
+            }}
+            endpoints={bcpuNames}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/Tables/BramTable.js
+++ b/src/components/Tables/BramTable.js
@@ -150,105 +150,103 @@ function BramTable({ device, totalPowerCallback }) {
 
   return (
     <div className="component-table-head">
-      <div className="main-block">
-        <ComponentLabel name="BRAM" />
-        <div className="power-and-table-wrapper">
-          <div className="power-table-wrapper">
-            <PowerTable
-              title="BRAM power"
-              total={powerTotal}
-              resourcesHeaders={resourcesHeaders}
-              resources={powerTable}
-            />
-          </div>
-          <TableBase
-            header={mainTableHeader}
-            disabled={device === null}
-            onClick={() => setModalOpen(true)}
-          >
-            {
-            bramData.map((row, index) => (
-              <React.Fragment key={row.name}>
-                <tr>
-                  <Actions
-                    rowSpan={2}
-                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                    onDeleteClick={() => deleteRow(index)}
-                  />
-                  <td rowSpan={2}>
-                    <Checkbox
-                      isChecked={row.enable}
-                      checkHandler={(state) => enableChanged(index, state)}
-                      id={index}
-                    />
-                  </td>
-                  <td rowSpan={2}>{row.name}</td>
-                  <td rowSpan={2}>{GetText(row.type, bramType)}</td>
-                  <td rowSpan={2}>{row.bram_used}</td>
-                  <td>A - Write</td>
-                  <td>{row.port_a.clock}</td>
-                  <td>{row.port_a.width}</td>
-                  <PercentsCell val={row.port_a.write_enable_rate} />
-                  <PercentsCell val={row.port_a.read_enable_rate} />
-                  <PercentsCell val={row.port_a.toggle_rate} precition={1} />
-                  <FrequencyCell val={row.consumption.port_a.clock_frequency} />
-                  <td>
-                    {fixed(row.consumption.port_a.output_signal_rate, 1)}
-                    {' MTr/S'}
-                  </td>
-                  <td>{row.consumption.port_a.ram_depth}</td>
-                  <PowerCell rowSpan={2} val={row.consumption.block_power} />
-                  <PowerCell rowSpan={2} val={row.consumption.interconnect_power} />
-                  <td rowSpan={2}>
-                    {fixed(row.consumption.percentage, 0)}
-                    {' %'}
-                  </td>
-                </tr>
-                <tr>
-                  <td>B - Read</td>
-                  <td>{row.port_b.clock}</td>
-                  <td>{row.port_b.width}</td>
-                  <PercentsCell val={row.port_b.write_enable_rate} />
-                  <PercentsCell val={row.port_b.read_enable_rate} />
-                  <PercentsCell val={row.port_b.toggle_rate} precition={1} />
-                  <FrequencyCell val={row.consumption.port_b.clock_frequency} />
-                  <td>
-                    {fixed(row.consumption.port_b.output_signal_rate, 1)}
-                    {' MTr/S'}
-                  </td>
-                  <td>{row.consumption.port_b.ram_depth}</td>
-                </tr>
-              </React.Fragment>
-            ))
-          }
-          </TableBase>
-        </div>
-        {modalOpen && (
-          <BramModal
-            closeModal={() => {
-              setModalOpen(false);
-              setEditIndex(null);
-            }}
-            onSubmit={handleSubmit}
-            defaultValue={(editIndex !== null && bramWindowData[editIndex]) || {
-              enable: true,
-              name: '',
-              type: 0,
-              bram_used: 0,
-              port_a_clock: '',
-              port_a_width: 0,
-              port_b_clock: '',
-              port_b_width: 0,
-              port_a_write_enable_rate: 0,
-              port_a_read_enable_rate: 0,
-              port_a_toggle_rate: 0,
-              port_b_write_enable_rate: 0,
-              port_b_read_enable_rate: 0,
-              port_b_toggle_rate: 0,
-            }}
+      <ComponentLabel name="BRAM" />
+      <div className="power-and-table-wrapper">
+        <div className="power-table-wrapper">
+          <PowerTable
+            title="BRAM power"
+            total={powerTotal}
+            resourcesHeaders={resourcesHeaders}
+            resources={powerTable}
           />
-        )}
+        </div>
+        <TableBase
+          header={mainTableHeader}
+          disabled={device === null}
+          onClick={() => setModalOpen(true)}
+        >
+          {
+          bramData.map((row, index) => (
+            <React.Fragment key={row.name}>
+              <tr>
+                <Actions
+                  rowSpan={2}
+                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                  onDeleteClick={() => deleteRow(index)}
+                />
+                <td rowSpan={2}>
+                  <Checkbox
+                    isChecked={row.enable}
+                    checkHandler={(state) => enableChanged(index, state)}
+                    id={index}
+                  />
+                </td>
+                <td rowSpan={2}>{row.name}</td>
+                <td rowSpan={2}>{GetText(row.type, bramType)}</td>
+                <td rowSpan={2}>{row.bram_used}</td>
+                <td>A - Write</td>
+                <td>{row.port_a.clock}</td>
+                <td>{row.port_a.width}</td>
+                <PercentsCell val={row.port_a.write_enable_rate} />
+                <PercentsCell val={row.port_a.read_enable_rate} />
+                <PercentsCell val={row.port_a.toggle_rate} precition={1} />
+                <FrequencyCell val={row.consumption.port_a.clock_frequency} />
+                <td>
+                  {fixed(row.consumption.port_a.output_signal_rate, 1)}
+                  {' MTr/S'}
+                </td>
+                <td>{row.consumption.port_a.ram_depth}</td>
+                <PowerCell rowSpan={2} val={row.consumption.block_power} />
+                <PowerCell rowSpan={2} val={row.consumption.interconnect_power} />
+                <td rowSpan={2}>
+                  {fixed(row.consumption.percentage, 0)}
+                  {' %'}
+                </td>
+              </tr>
+              <tr>
+                <td>B - Read</td>
+                <td>{row.port_b.clock}</td>
+                <td>{row.port_b.width}</td>
+                <PercentsCell val={row.port_b.write_enable_rate} />
+                <PercentsCell val={row.port_b.read_enable_rate} />
+                <PercentsCell val={row.port_b.toggle_rate} precition={1} />
+                <FrequencyCell val={row.consumption.port_b.clock_frequency} />
+                <td>
+                  {fixed(row.consumption.port_b.output_signal_rate, 1)}
+                  {' MTr/S'}
+                </td>
+                <td>{row.consumption.port_b.ram_depth}</td>
+              </tr>
+            </React.Fragment>
+          ))
+        }
+        </TableBase>
       </div>
+      {modalOpen && (
+      <BramModal
+        closeModal={() => {
+          setModalOpen(false);
+          setEditIndex(null);
+        }}
+        onSubmit={handleSubmit}
+        defaultValue={(editIndex !== null && bramWindowData[editIndex]) || {
+          enable: true,
+          name: '',
+          type: 0,
+          bram_used: 0,
+          port_a_clock: '',
+          port_a_width: 0,
+          port_b_clock: '',
+          port_b_width: 0,
+          port_a_write_enable_rate: 0,
+          port_a_read_enable_rate: 0,
+          port_a_toggle_rate: 0,
+          port_b_write_enable_rate: 0,
+          port_b_read_enable_rate: 0,
+          port_b_toggle_rate: 0,
+        }}
+      />
+      )}
     </div>
   );
 }

--- a/src/components/Tables/BramTable.js
+++ b/src/components/Tables/BramTable.js
@@ -149,7 +149,7 @@ function BramTable({ device, totalPowerCallback }) {
   }
 
   return (
-    <div className="component-table-head main-border">
+    <div className="component-table-head">
       <div className="main-block">
         <ComponentLabel name="BRAM" />
         <div className="power-and-table-wrapper">

--- a/src/components/Tables/BramTable.js
+++ b/src/components/Tables/BramTable.js
@@ -148,9 +148,11 @@ function BramTable({ device, totalPowerCallback }) {
     );
   }
 
+  const title = 'BRAM';
+
   return (
     <div className="component-table-head">
-      <ComponentLabel name="BRAM" />
+      <ComponentLabel name={title} />
       <div className="power-and-table-wrapper">
         <div className="power-table-wrapper">
           <PowerTable
@@ -224,6 +226,7 @@ function BramTable({ device, totalPowerCallback }) {
       </div>
       {modalOpen && (
       <BramModal
+        title={title}
         closeModal={() => {
           setModalOpen(false);
           setEditIndex(null);

--- a/src/components/Tables/ClockingTable.js
+++ b/src/components/Tables/ClockingTable.js
@@ -105,71 +105,69 @@ function ClockingTable({ device, totalPowerCallback }) {
 
   return (
     <div className="component-table-head">
-      <div className="main-block">
-        <ComponentLabel name="Clocking" />
-        <div className="power-and-table-wrapper">
-          <div className="power-table-wrapper">
-            <PowerTable
-              title="Clock power"
-              total={powerTotal}
-              resourcesHeaders={resourcesHeaders}
-              resources={powerTable}
-            />
-          </div>
-          <TableBase
-            header={mainTableHeader}
-            disabled={device === null}
-            onClick={() => setModalOpen(true)}
-          >
-            {
-            clockingData.map((row, index) => (
-              <tr key={row.description}>
-                <Actions
-                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                  onDeleteClick={() => deleteRow(index)}
-                />
-                <td>
-                  <Checkbox
-                    isChecked={row.enable}
-                    checkHandler={(state) => enableChanged(index, state)}
-                    id={index}
-                  />
-                </td>
-                <td>{row.description}</td>
-                <td>{GetText(row.source, sources)}</td>
-                <td>{row.port}</td>
-                <FrequencyCell val={row.frequency} />
-                <td>{GetText(row.state, states)}</td>
-                <td>{row.consumption.fan_out}</td>
-                <PowerCell val={row.consumption.block_power} />
-                <PowerCell val={row.consumption.interconnect_power} />
-                <td>
-                  {fixed(row.consumption.percentage, 0)}
-                  {' %'}
-                </td>
-              </tr>
-            ))
-          }
-          </TableBase>
-        </div>
-        {modalOpen && (
-          <ClockingModal
-            closeModal={() => {
-              setModalOpen(false);
-              setEditIndex(null);
-            }}
-            onSubmit={handleSubmit}
-            defaultValue={(editIndex !== null && clockingData[editIndex]) || {
-              enable: true,
-              source: 0,
-              description: '',
-              port: '',
-              frequency: 1000000,
-              state: 1,
-            }}
+      <ComponentLabel name="Clocking" />
+      <div className="power-and-table-wrapper">
+        <div className="power-table-wrapper">
+          <PowerTable
+            title="Clock power"
+            total={powerTotal}
+            resourcesHeaders={resourcesHeaders}
+            resources={powerTable}
           />
-        )}
+        </div>
+        <TableBase
+          header={mainTableHeader}
+          disabled={device === null}
+          onClick={() => setModalOpen(true)}
+        >
+          {
+          clockingData.map((row, index) => (
+            <tr key={row.description}>
+              <Actions
+                onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                onDeleteClick={() => deleteRow(index)}
+              />
+              <td>
+                <Checkbox
+                  isChecked={row.enable}
+                  checkHandler={(state) => enableChanged(index, state)}
+                  id={index}
+                />
+              </td>
+              <td>{row.description}</td>
+              <td>{GetText(row.source, sources)}</td>
+              <td>{row.port}</td>
+              <FrequencyCell val={row.frequency} />
+              <td>{GetText(row.state, states)}</td>
+              <td>{row.consumption.fan_out}</td>
+              <PowerCell val={row.consumption.block_power} />
+              <PowerCell val={row.consumption.interconnect_power} />
+              <td>
+                {fixed(row.consumption.percentage, 0)}
+                {' %'}
+              </td>
+            </tr>
+          ))
+        }
+        </TableBase>
       </div>
+      {modalOpen && (
+      <ClockingModal
+        closeModal={() => {
+          setModalOpen(false);
+          setEditIndex(null);
+        }}
+        onSubmit={handleSubmit}
+        defaultValue={(editIndex !== null && clockingData[editIndex]) || {
+          enable: true,
+          source: 0,
+          description: '',
+          port: '',
+          frequency: 1000000,
+          state: 1,
+        }}
+      />
+      )}
     </div>
   );
 }

--- a/src/components/Tables/ClockingTable.js
+++ b/src/components/Tables/ClockingTable.js
@@ -104,7 +104,7 @@ function ClockingTable({ device, totalPowerCallback }) {
   }
 
   return (
-    <div className="component-table-head main-border">
+    <div className="component-table-head">
       <div className="main-block">
         <ComponentLabel name="Clocking" />
         <div className="power-and-table-wrapper">

--- a/src/components/Tables/ClockingTable.js
+++ b/src/components/Tables/ClockingTable.js
@@ -103,9 +103,11 @@ function ClockingTable({ device, totalPowerCallback }) {
     );
   }
 
+  const title = 'Clocking';
+
   return (
     <div className="component-table-head">
-      <ComponentLabel name="Clocking" />
+      <ComponentLabel name={title} />
       <div className="power-and-table-wrapper">
         <div className="power-table-wrapper">
           <PowerTable
@@ -153,6 +155,7 @@ function ClockingTable({ device, totalPowerCallback }) {
       </div>
       {modalOpen && (
       <ClockingModal
+        title={title}
         closeModal={() => {
           setModalOpen(false);
           setEditIndex(null);

--- a/src/components/Tables/ConnectivityTable.js
+++ b/src/components/Tables/ConnectivityTable.js
@@ -112,9 +112,10 @@ function ConnectivityTable({ device }) {
   };
 
   const powerHeader = ['Power', '%'];
+  const title = 'Connectivity';
   return (
     <div className="component-table-head">
-      <ComponentLabel name="Connectivity" />
+      <ComponentLabel name={title} />
       <div className="cpu-container">
         <div className="power-and-table-wrapper">
           <PowerTable
@@ -155,31 +156,31 @@ function ConnectivityTable({ device }) {
           }
           </TableBase>
         </div>
-        {modalOpen
-          && (
-            <ConnectivityModal
-              closeModal={() => {
-                setModalOpen(false);
-                setEditIndex(null);
-              }}
-              onSubmit={handleSubmit}
-              defaultValue={(editIndex !== null && {
-                name: connectivityNames.indexOf(connectivityNames.find(
-                  (elem) => elem.text === endpoints[editIndex].data.name,
-                )),
-                clock: endpoints[editIndex].data.clock,
-                activity: endpoints[editIndex].data.activity,
-                read_write_rate: endpoints[editIndex].data.read_write_rate,
-                toggle_rate: endpoints[editIndex].data.toggle_rate,
-              }) || {
-                name: 0,
-                clock: '',
-                activity: 0,
-                read_write_rate: 0.5,
-                toggle_rate: 0.125,
-              }}
-            />
-          )}
+        {modalOpen && (
+        <ConnectivityModal
+          title={title}
+          closeModal={() => {
+            setModalOpen(false);
+            setEditIndex(null);
+          }}
+          onSubmit={handleSubmit}
+          defaultValue={(editIndex !== null && {
+            name: connectivityNames.indexOf(connectivityNames.find(
+              (elem) => elem.text === endpoints[editIndex].data.name,
+            )),
+            clock: endpoints[editIndex].data.clock,
+            activity: endpoints[editIndex].data.activity,
+            read_write_rate: endpoints[editIndex].data.read_write_rate,
+            toggle_rate: endpoints[editIndex].data.toggle_rate,
+          }) || {
+            name: 0,
+            clock: '',
+            activity: 0,
+            read_write_rate: 0.5,
+            toggle_rate: 0.125,
+          }}
+        />
+        )}
       </div>
     </div>
   );

--- a/src/components/Tables/ConnectivityTable.js
+++ b/src/components/Tables/ConnectivityTable.js
@@ -114,74 +114,72 @@ function ConnectivityTable({ device }) {
   const powerHeader = ['Power', '%'];
   return (
     <div className="component-table-head">
-      <div className="main-block">
-        <ComponentLabel name="Connectivity" />
-        <div className="cpu-container">
-          <div className="power-and-table-wrapper">
-            <PowerTable
-              title="Connectivity power"
-              total={null}
-              resourcesHeaders={powerHeader}
-              resources={powerData}
-              subHeader="Sub System"
-            />
-            <TableBase
-              header={header}
-              disabled={addButtonDisable}
-              onClick={() => setModalOpen(true)}
-            >
-              {
-              endpoints.map((row, index) => (
-                (row.data !== undefined && row.data.name !== '') && (
-                <tr key={row.ep}>
-                  <Actions
-                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                    onDeleteClick={() => deleteRow(index)}
-                  />
-                  <td>{row.data.clock}</td>
-                  <FrequencyCell val={row.data.consumption.clock_frequency} />
-                  <td>{row.data.name}</td>
-                  <SelectionCell val={row.data.activity} values={loadActivity} />
-                  <PercentsCell val={row.data.read_write_rate} />
-                  <PercentsCell val={row.data.toggle_rate} precition={1} />
-                  <PowerCell val={row.data.consumption.calculated_bandwidth} />
-                  <PowerCell val={row.data.consumption.noc_power} />
-                  <td>
-                    {fixed(row.data.consumption.percentage, 0)}
-                    {' %'}
-                  </td>
-                </tr>
-                )
-              ))
-            }
-            </TableBase>
-          </div>
-          {modalOpen
-            && (
-              <ConnectivityModal
-                closeModal={() => {
-                  setModalOpen(false);
-                  setEditIndex(null);
-                }}
-                onSubmit={handleSubmit}
-                defaultValue={(editIndex !== null && {
-                  name: connectivityNames.indexOf(connectivityNames.find(
-                    (elem) => elem.text === endpoints[editIndex].data.name,
-                  )),
-                  clock: endpoints[editIndex].data.clock,
-                  activity: endpoints[editIndex].data.activity,
-                  read_write_rate: endpoints[editIndex].data.read_write_rate,
-                  toggle_rate: endpoints[editIndex].data.toggle_rate,
-                }) || {
-                  name: 0,
-                  clock: '',
-                  activity: 0,
-                  read_write_rate: 0.5,
-                  toggle_rate: 0.125,
-                }}
-              />
-            )}
+      <ComponentLabel name="Connectivity" />
+      <div className="cpu-container">
+        <div className="power-and-table-wrapper">
+          <PowerTable
+            title="Connectivity power"
+            total={null}
+            resourcesHeaders={powerHeader}
+            resources={powerData}
+            subHeader="Sub System"
+          />
+          <TableBase
+            header={header}
+            disabled={addButtonDisable}
+            onClick={() => setModalOpen(true)}
+          >
+            {
+            endpoints.map((row, index) => (
+              (row.data !== undefined && row.data.name !== '') && (
+              <tr key={row.ep}>
+                <Actions
+                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                  onDeleteClick={() => deleteRow(index)}
+                />
+                <td>{row.data.clock}</td>
+                <FrequencyCell val={row.data.consumption.clock_frequency} />
+                <td>{row.data.name}</td>
+                <SelectionCell val={row.data.activity} values={loadActivity} />
+                <PercentsCell val={row.data.read_write_rate} />
+                <PercentsCell val={row.data.toggle_rate} precition={1} />
+                <PowerCell val={row.data.consumption.calculated_bandwidth} />
+                <PowerCell val={row.data.consumption.noc_power} />
+                <td>
+                  {fixed(row.data.consumption.percentage, 0)}
+                  {' %'}
+                </td>
+              </tr>
+              )
+            ))
+          }
+          </TableBase>
         </div>
+        {modalOpen
+          && (
+            <ConnectivityModal
+              closeModal={() => {
+                setModalOpen(false);
+                setEditIndex(null);
+              }}
+              onSubmit={handleSubmit}
+              defaultValue={(editIndex !== null && {
+                name: connectivityNames.indexOf(connectivityNames.find(
+                  (elem) => elem.text === endpoints[editIndex].data.name,
+                )),
+                clock: endpoints[editIndex].data.clock,
+                activity: endpoints[editIndex].data.activity,
+                read_write_rate: endpoints[editIndex].data.read_write_rate,
+                toggle_rate: endpoints[editIndex].data.toggle_rate,
+              }) || {
+                name: 0,
+                clock: '',
+                activity: 0,
+                read_write_rate: 0.5,
+                toggle_rate: 0.125,
+              }}
+            />
+          )}
       </div>
     </div>
   );

--- a/src/components/Tables/ConnectivityTable.js
+++ b/src/components/Tables/ConnectivityTable.js
@@ -113,7 +113,7 @@ function ConnectivityTable({ device }) {
 
   const powerHeader = ['Power', '%'];
   return (
-    <div className="acpu-container main-border">
+    <div className="component-table-head">
       <div className="main-block">
         <ComponentLabel name="Connectivity" />
         <div className="cpu-container">

--- a/src/components/Tables/DMATable.js
+++ b/src/components/Tables/DMATable.js
@@ -107,7 +107,7 @@ function DMATable({ device }) {
   }
 
   return (
-    <div className="component-table-head main-border">
+    <div className="component-table-head">
       <div className="main-block">
         <ComponentLabel name="DMA" />
         <div className="power-and-table-wrapper">

--- a/src/components/Tables/DMATable.js
+++ b/src/components/Tables/DMATable.js
@@ -106,9 +106,11 @@ function DMATable({ device }) {
     updateTotalPower(device);
   }
 
+  const title = 'DMA';
+
   return (
     <div className="component-table-head">
-      <ComponentLabel name="DMA" />
+      <ComponentLabel name={title} />
       <div className="power-and-table-wrapper">
         <div className="power-table-wrapper">
           <PowerTable
@@ -158,6 +160,7 @@ function DMATable({ device }) {
       </div>
       {modalOpen && (
         <DMAModal
+          title={title}
           closeModal={() => {
             setModalOpen(false);
             setEditIndex(null);

--- a/src/components/Tables/DMATable.js
+++ b/src/components/Tables/DMATable.js
@@ -108,56 +108,55 @@ function DMATable({ device }) {
 
   return (
     <div className="component-table-head">
-      <div className="main-block">
-        <ComponentLabel name="DMA" />
-        <div className="power-and-table-wrapper">
-          <div className="power-table-wrapper">
-            <PowerTable
-              title="DMA power"
-              total={null}
-              resourcesHeaders={resourcesHeaders}
-              resources={powerTable}
-              subHeader="Sub System"
-            />
-          </div>
-          <TableBase
-            header={mainTableHeader}
-            hideAddBtn
-            onClick={() => setModalOpen(true)}
-          >
-            {
-            dmaData.map((row, index) => (
-              (row.data.consumption !== undefined) && (
-                <tr key={row.id}>
-                  <Actions
-                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                  />
-                  <td>
-                    <Checkbox
-                      isChecked={row.data.enable}
-                      checkHandler={(state) => enableChanged(index, state)}
-                      id={index}
-                    />
-                  </td>
-                  <td>{row.data.name}</td>
-                  <SelectionCell val={row.data.source} values={source} />
-                  <SelectionCell val={row.data.destination} values={source} />
-                  <SelectionCell val={row.data.activity} values={loadActivity} />
-                  <PercentsCell val={row.data.read_write_rate} />
-                  <PercentsCell val={row.data.toggle_rate} precition={1} />
-                  <PowerCell val={row.data.consumption.calculated_bandwidth} />
-                  <PowerCell val={row.data.consumption.block_power} />
-                  <td>
-                    {fixed(row.data.consumption.percentage, 0)}
-                    {' %'}
-                  </td>
-                </tr>
-              )
-            ))
-          }
-          </TableBase>
+      <ComponentLabel name="DMA" />
+      <div className="power-and-table-wrapper">
+        <div className="power-table-wrapper">
+          <PowerTable
+            title="DMA power"
+            total={null}
+            resourcesHeaders={resourcesHeaders}
+            resources={powerTable}
+            subHeader="Sub System"
+          />
         </div>
-        {modalOpen && (
+        <TableBase
+          header={mainTableHeader}
+          hideAddBtn
+          onClick={() => setModalOpen(true)}
+        >
+          {
+          dmaData.map((row, index) => (
+            (row.data.consumption !== undefined) && (
+              <tr key={row.id}>
+                <Actions
+                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                />
+                <td>
+                  <Checkbox
+                    isChecked={row.data.enable}
+                    checkHandler={(state) => enableChanged(index, state)}
+                    id={index}
+                  />
+                </td>
+                <td>{row.data.name}</td>
+                <SelectionCell val={row.data.source} values={source} />
+                <SelectionCell val={row.data.destination} values={source} />
+                <SelectionCell val={row.data.activity} values={loadActivity} />
+                <PercentsCell val={row.data.read_write_rate} />
+                <PercentsCell val={row.data.toggle_rate} precition={1} />
+                <PowerCell val={row.data.consumption.calculated_bandwidth} />
+                <PowerCell val={row.data.consumption.block_power} />
+                <td>
+                  {fixed(row.data.consumption.percentage, 0)}
+                  {' %'}
+                </td>
+              </tr>
+            )
+          ))
+        }
+        </TableBase>
+      </div>
+      {modalOpen && (
         <DMAModal
           closeModal={() => {
             setModalOpen(false);
@@ -174,8 +173,7 @@ function DMATable({ device }) {
             toggle_rate: 0,
           }}
         />
-        )}
-      </div>
+      )}
     </div>
   );
 }

--- a/src/components/Tables/DesignParametesTable.js
+++ b/src/components/Tables/DesignParametesTable.js
@@ -4,7 +4,7 @@ import '../style/DesignParametesTable.css';
 
 function DesignParametesTable() {
   return (
-    <div className="param-element-container main-border">
+    <div className="param-element-container">
       <div className="param-element">
         <div>LUTs</div>
         <select>

--- a/src/components/Tables/DspTable.js
+++ b/src/components/Tables/DspTable.js
@@ -98,83 +98,81 @@ function DspTable({ device, totalPowerCallback }) {
 
   return (
     <div className="component-table-head">
-      <div className="main-block">
-        <ComponentLabel name="DSP" />
-        <div className="power-and-table-wrapper">
-          <div className="power-table-wrapper">
-            <PowerTable
-              title="DSP power"
-              total={powerTotal}
-              resourcesHeaders={resourcesHeaders}
-              resources={powerTable}
-            />
-          </div>
-          <TableBase
-            header={mainTableHeader}
-            disabled={device === null}
-            onClick={() => setModalOpen(true)}
-          >
-            {
-            dspData.map((row, index) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <tr key={index}>
-                <Actions
-                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                  onDeleteClick={() => deleteRow(index)}
-                />
-                <td>
-                  <Checkbox
-                    isChecked={row.enable}
-                    checkHandler={(state) => enableChanged(index, state)}
-                    id={index}
-                  />
-                </td>
-                <td>{row.name}</td>
-                <td>{row.number_of_multipliers}</td>
-                <td>{GetText(row.dsp_mode, dspMode)}</td>
-                <td>{row.a_input_width}</td>
-                <td>{row.b_input_width}</td>
-                <td>{row.clock}</td>
-                <td>{GetText(row.pipelining, pipelining)}</td>
-                <PercentsCell val={row.toggle_rate} precition={1} />
-                <td>{row.consumption.dsp_blocks_used}</td>
-                <FrequencyCell val={row.consumption.clock_frequency} />
-                <td>
-                  {fixed(row.consumption.output_signal_rate, 1)}
-                  {' MTr/S'}
-                </td>
-                <PowerCell val={row.consumption.block_power} />
-                <PowerCell val={row.consumption.interconnect_power} />
-                <td>
-                  {fixed(row.consumption.percentage, 0)}
-                  {' %'}
-                </td>
-              </tr>
-            ))
-          }
-          </TableBase>
-        </div>
-        {modalOpen && (
-          <DspModal
-            closeModal={() => {
-              setModalOpen(false);
-              setEditIndex(null);
-            }}
-            onSubmit={handleSubmit}
-            defaultValue={(editIndex !== null && dspData[editIndex]) || {
-              enable: true,
-              name: '',
-              number_of_multipliers: 0,
-              dsp_mode: 0,
-              a_input_width: 0,
-              b_input_width: 0,
-              clock: '',
-              pipelining: 0,
-              toggle_rate: 0,
-            }}
+      <ComponentLabel name="DSP" />
+      <div className="power-and-table-wrapper">
+        <div className="power-table-wrapper">
+          <PowerTable
+            title="DSP power"
+            total={powerTotal}
+            resourcesHeaders={resourcesHeaders}
+            resources={powerTable}
           />
-        )}
+        </div>
+        <TableBase
+          header={mainTableHeader}
+          disabled={device === null}
+          onClick={() => setModalOpen(true)}
+        >
+          {
+          dspData.map((row, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <tr key={index}>
+              <Actions
+                onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                onDeleteClick={() => deleteRow(index)}
+              />
+              <td>
+                <Checkbox
+                  isChecked={row.enable}
+                  checkHandler={(state) => enableChanged(index, state)}
+                  id={index}
+                />
+              </td>
+              <td>{row.name}</td>
+              <td>{row.number_of_multipliers}</td>
+              <td>{GetText(row.dsp_mode, dspMode)}</td>
+              <td>{row.a_input_width}</td>
+              <td>{row.b_input_width}</td>
+              <td>{row.clock}</td>
+              <td>{GetText(row.pipelining, pipelining)}</td>
+              <PercentsCell val={row.toggle_rate} precition={1} />
+              <td>{row.consumption.dsp_blocks_used}</td>
+              <FrequencyCell val={row.consumption.clock_frequency} />
+              <td>
+                {fixed(row.consumption.output_signal_rate, 1)}
+                {' MTr/S'}
+              </td>
+              <PowerCell val={row.consumption.block_power} />
+              <PowerCell val={row.consumption.interconnect_power} />
+              <td>
+                {fixed(row.consumption.percentage, 0)}
+                {' %'}
+              </td>
+            </tr>
+          ))
+        }
+        </TableBase>
       </div>
+      {modalOpen && (
+      <DspModal
+        closeModal={() => {
+          setModalOpen(false);
+          setEditIndex(null);
+        }}
+        onSubmit={handleSubmit}
+        defaultValue={(editIndex !== null && dspData[editIndex]) || {
+          enable: true,
+          name: '',
+          number_of_multipliers: 0,
+          dsp_mode: 0,
+          a_input_width: 0,
+          b_input_width: 0,
+          clock: '',
+          pipelining: 0,
+          toggle_rate: 0,
+        }}
+      />
+      )}
     </div>
   );
 }

--- a/src/components/Tables/DspTable.js
+++ b/src/components/Tables/DspTable.js
@@ -97,7 +97,7 @@ function DspTable({ device, totalPowerCallback }) {
   }
 
   return (
-    <div className="component-table-head main-border">
+    <div className="component-table-head">
       <div className="main-block">
         <ComponentLabel name="DSP" />
         <div className="power-and-table-wrapper">

--- a/src/components/Tables/DspTable.js
+++ b/src/components/Tables/DspTable.js
@@ -96,9 +96,11 @@ function DspTable({ device, totalPowerCallback }) {
     );
   }
 
+  const title = 'DSP';
+
   return (
     <div className="component-table-head">
-      <ComponentLabel name="DSP" />
+      <ComponentLabel name={title} />
       <div className="power-and-table-wrapper">
         <div className="power-table-wrapper">
           <PowerTable
@@ -155,6 +157,7 @@ function DspTable({ device, totalPowerCallback }) {
       </div>
       {modalOpen && (
       <DspModal
+        title={title}
         closeModal={() => {
           setModalOpen(false);
           setEditIndex(null);

--- a/src/components/Tables/FleTable.js
+++ b/src/components/Tables/FleTable.js
@@ -99,9 +99,11 @@ function FleTable({ device, totalPowerCallback }) {
     );
   }
 
+  const title = 'FLE';
+
   return (
     <div className="component-table-head">
-      <ComponentLabel name="FLE" />
+      <ComponentLabel name={title} />
       <div className="power-and-table-wrapper">
         <div className="power-table-wrapper">
           <PowerTable
@@ -155,6 +157,7 @@ function FleTable({ device, totalPowerCallback }) {
       </div>
       {modalOpen && (
       <FleModal
+        title={title}
         closeModal={() => {
           setModalOpen(false);
           setEditIndex(null);

--- a/src/components/Tables/FleTable.js
+++ b/src/components/Tables/FleTable.js
@@ -101,79 +101,77 @@ function FleTable({ device, totalPowerCallback }) {
 
   return (
     <div className="component-table-head">
-      <div className="main-block">
-        <ComponentLabel name="FLE" />
-        <div className="power-and-table-wrapper">
-          <div className="power-table-wrapper">
-            <PowerTable
-              title="FLE power"
-              total={powerTotal}
-              resourcesHeaders={resourcesHeaders}
-              resources={powerTable}
-            />
-          </div>
-          <TableBase
-            header={mainTableHeader}
-            disabled={device === null}
-            onClick={() => setModalOpen(true)}
-          >
-            {
-            fleData.map((row, index) => (
-              <tr key={row.name}>
-                <Actions
-                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                  onDeleteClick={() => deleteRow(index)}
-                />
-                <td>
-                  <Checkbox
-                    isChecked={row.enable}
-                    checkHandler={(state) => enableChanged(index, state)}
-                    id={index}
-                  />
-                </td>
-                <td>{row.name}</td>
-                <td>{row.lut6}</td>
-                <td>{row.flip_flop}</td>
-                <td>{row.clock}</td>
-                <PercentsCell val={row.toggle_rate} precition={1} />
-                <td>{GetText(row.glitch_factor, glitchFactor)}</td>
-                <PercentsCell val={row.clock_enable_rate} />
-                <FrequencyCell val={row.consumption.clock_frequency} />
-                <td>
-                  {fixed(row.consumption.output_signal_rate, 1)}
-                  {' MTr/S'}
-                </td>
-                <PowerCell val={row.consumption.block_power} />
-                <PowerCell val={row.consumption.interconnect_power} />
-                <td>
-                  {fixed(row.consumption.percentage, 0)}
-                  {' %'}
-                </td>
-              </tr>
-            ))
-          }
-          </TableBase>
-        </div>
-        {modalOpen && (
-          <FleModal
-            closeModal={() => {
-              setModalOpen(false);
-              setEditIndex(null);
-            }}
-            onSubmit={handleSubmit}
-            defaultValue={(editIndex !== null && fleData[editIndex]) || {
-              enable: true,
-              name: '',
-              lut6: 0,
-              flip_flop: 0,
-              clock: '',
-              toggle_rate: 0,
-              glitch_factor: 0,
-              clock_enable_rate: 0.0,
-            }}
+      <ComponentLabel name="FLE" />
+      <div className="power-and-table-wrapper">
+        <div className="power-table-wrapper">
+          <PowerTable
+            title="FLE power"
+            total={powerTotal}
+            resourcesHeaders={resourcesHeaders}
+            resources={powerTable}
           />
-        )}
+        </div>
+        <TableBase
+          header={mainTableHeader}
+          disabled={device === null}
+          onClick={() => setModalOpen(true)}
+        >
+          {
+          fleData.map((row, index) => (
+            <tr key={row.name}>
+              <Actions
+                onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                onDeleteClick={() => deleteRow(index)}
+              />
+              <td>
+                <Checkbox
+                  isChecked={row.enable}
+                  checkHandler={(state) => enableChanged(index, state)}
+                  id={index}
+                />
+              </td>
+              <td>{row.name}</td>
+              <td>{row.lut6}</td>
+              <td>{row.flip_flop}</td>
+              <td>{row.clock}</td>
+              <PercentsCell val={row.toggle_rate} precition={1} />
+              <td>{GetText(row.glitch_factor, glitchFactor)}</td>
+              <PercentsCell val={row.clock_enable_rate} />
+              <FrequencyCell val={row.consumption.clock_frequency} />
+              <td>
+                {fixed(row.consumption.output_signal_rate, 1)}
+                {' MTr/S'}
+              </td>
+              <PowerCell val={row.consumption.block_power} />
+              <PowerCell val={row.consumption.interconnect_power} />
+              <td>
+                {fixed(row.consumption.percentage, 0)}
+                {' %'}
+              </td>
+            </tr>
+          ))
+        }
+        </TableBase>
       </div>
+      {modalOpen && (
+      <FleModal
+        closeModal={() => {
+          setModalOpen(false);
+          setEditIndex(null);
+        }}
+        onSubmit={handleSubmit}
+        defaultValue={(editIndex !== null && fleData[editIndex]) || {
+          enable: true,
+          name: '',
+          lut6: 0,
+          flip_flop: 0,
+          clock: '',
+          toggle_rate: 0,
+          glitch_factor: 0,
+          clock_enable_rate: 0.0,
+        }}
+      />
+      )}
     </div>
   );
 }

--- a/src/components/Tables/FleTable.js
+++ b/src/components/Tables/FleTable.js
@@ -100,7 +100,7 @@ function FleTable({ device, totalPowerCallback }) {
   }
 
   return (
-    <div className="component-table-head main-border">
+    <div className="component-table-head">
       <div className="main-block">
         <ComponentLabel name="FLE" />
         <div className="power-and-table-wrapper">

--- a/src/components/Tables/IOTable.js
+++ b/src/components/Tables/IOTable.js
@@ -163,9 +163,11 @@ function IOTable({ device, totalPowerCallback }) {
     );
   }
 
+  const title = 'IO';
+
   return (
     <div className="component-table-head">
-      <ComponentLabel name="IO" />
+      <ComponentLabel name={title} />
       <div className="power-and-table-wrapper">
         <div className="power-table-wrapper">
           <IOPowerTable
@@ -229,6 +231,7 @@ function IOTable({ device, totalPowerCallback }) {
       </div>
       {modalOpen && (
       <IOModal
+        title={title}
         closeModal={() => {
           setModalOpen(false);
           setEditIndex(null);

--- a/src/components/Tables/IOTable.js
+++ b/src/components/Tables/IOTable.js
@@ -165,80 +165,78 @@ function IOTable({ device, totalPowerCallback }) {
 
   return (
     <div className="component-table-head">
-      <div className="main-block">
-        <ComponentLabel name="IO" />
-        <div className="power-and-table-wrapper">
-          <div className="power-table-wrapper">
-            <IOPowerTable
-              title="IO power"
-              total={powerTotal}
-              resources={powerTable !== null ? powerTable : defaultPowerData}
-            />
-          </div>
-          <TableBase
-            header={mainTableHeader}
-            disabled={device === null}
-            onClick={() => setModalOpen(true)}
-          >
-            {
-            ioData.map((row, index) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <tr key={index}>
-                <Actions
-                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                  onDeleteClick={() => deleteRow(index)}
-                />
-                <td>
-                  <Checkbox
-                    isChecked={row.enable}
-                    checkHandler={(state) => enableChanged(index, state)}
-                    id={index}
-                  />
-                </td>
-                <td>{row.name}</td>
-                <td>{row.bus_width}</td>
-                <SelectionCell val={row.direction} values={direction} />
-                <SelectionCell val={row.io_standard} values={ioStandard} />
-                <SelectionCell val={row.drive_strength} values={driveStrength} />
-                <SelectionCell val={row.slew_rate} values={slewRate} />
-                <SelectionCell
-                  val={row.differential_termination}
-                  values={differentialTermination}
-                />
-                <SelectionCell val={row.io_data_type} values={ioDataType} />
-                <td>{row.clock}</td>
-                <PercentsCell val={row.toggle_rate} precition={1} />
-                <PercentsCell val={row.duty_cycle} />
-                <SelectionCell val={row.synchronization} values={synchronization} />
-                <PercentsCell val={row.input_enable_rate} />
-                <PercentsCell val={row.output_enable_rate} />
-                <SelectionCell val={row.io_pull_up_down} values={ioPullUpDown} />
-                <SelectionCell val={row.consumption.bank_type} values={bankType} />
-                <td>{row.consumption.bank_number}</td>
-                <td>{row.consumption.vccio_voltage}</td>
-                <PercentsCell val={row.consumption.io_signal_rate} />
-                <PowerCell val={row.consumption.block_power} />
-                <PowerCell val={row.consumption.interconnect_power} />
-                <td>
-                  {fixed(row.consumption.percentage, 0)}
-                  {' %'}
-                </td>
-              </tr>
-            ))
-          }
-          </TableBase>
-        </div>
-        {modalOpen && (
-          <IOModal
-            closeModal={() => {
-              setModalOpen(false);
-              setEditIndex(null);
-            }}
-            onSubmit={handleSubmit}
-            defaultValue={(editIndex !== null && ioData[editIndex]) || defaultIOData}
+      <ComponentLabel name="IO" />
+      <div className="power-and-table-wrapper">
+        <div className="power-table-wrapper">
+          <IOPowerTable
+            title="IO power"
+            total={powerTotal}
+            resources={powerTable !== null ? powerTable : defaultPowerData}
           />
-        )}
+        </div>
+        <TableBase
+          header={mainTableHeader}
+          disabled={device === null}
+          onClick={() => setModalOpen(true)}
+        >
+          {
+          ioData.map((row, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <tr key={index}>
+              <Actions
+                onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                onDeleteClick={() => deleteRow(index)}
+              />
+              <td>
+                <Checkbox
+                  isChecked={row.enable}
+                  checkHandler={(state) => enableChanged(index, state)}
+                  id={index}
+                />
+              </td>
+              <td>{row.name}</td>
+              <td>{row.bus_width}</td>
+              <SelectionCell val={row.direction} values={direction} />
+              <SelectionCell val={row.io_standard} values={ioStandard} />
+              <SelectionCell val={row.drive_strength} values={driveStrength} />
+              <SelectionCell val={row.slew_rate} values={slewRate} />
+              <SelectionCell
+                val={row.differential_termination}
+                values={differentialTermination}
+              />
+              <SelectionCell val={row.io_data_type} values={ioDataType} />
+              <td>{row.clock}</td>
+              <PercentsCell val={row.toggle_rate} precition={1} />
+              <PercentsCell val={row.duty_cycle} />
+              <SelectionCell val={row.synchronization} values={synchronization} />
+              <PercentsCell val={row.input_enable_rate} />
+              <PercentsCell val={row.output_enable_rate} />
+              <SelectionCell val={row.io_pull_up_down} values={ioPullUpDown} />
+              <SelectionCell val={row.consumption.bank_type} values={bankType} />
+              <td>{row.consumption.bank_number}</td>
+              <td>{row.consumption.vccio_voltage}</td>
+              <PercentsCell val={row.consumption.io_signal_rate} />
+              <PowerCell val={row.consumption.block_power} />
+              <PowerCell val={row.consumption.interconnect_power} />
+              <td>
+                {fixed(row.consumption.percentage, 0)}
+                {' %'}
+              </td>
+            </tr>
+          ))
+        }
+        </TableBase>
       </div>
+      {modalOpen && (
+      <IOModal
+        closeModal={() => {
+          setModalOpen(false);
+          setEditIndex(null);
+        }}
+        onSubmit={handleSubmit}
+        defaultValue={(editIndex !== null && ioData[editIndex]) || defaultIOData}
+      />
+      )}
     </div>
   );
 }

--- a/src/components/Tables/IOTable.js
+++ b/src/components/Tables/IOTable.js
@@ -164,7 +164,7 @@ function IOTable({ device, totalPowerCallback }) {
   }
 
   return (
-    <div className="component-table-head main-border">
+    <div className="component-table-head">
       <div className="main-block">
         <ComponentLabel name="IO" />
         <div className="power-and-table-wrapper">

--- a/src/components/Tables/MemoryTable.js
+++ b/src/components/Tables/MemoryTable.js
@@ -97,7 +97,7 @@ function MemoryTable({ device }) {
   }
 
   return (
-    <div className="component-table-head main-border">
+    <div className="component-table-head">
       <div className="main-block">
         <ComponentLabel name="Memory" />
         <div className="power-and-table-wrapper">

--- a/src/components/Tables/MemoryTable.js
+++ b/src/components/Tables/MemoryTable.js
@@ -98,54 +98,53 @@ function MemoryTable({ device }) {
 
   return (
     <div className="component-table-head">
-      <div className="main-block">
-        <ComponentLabel name="Memory" />
-        <div className="power-and-table-wrapper">
-          <div className="power-table-wrapper">
-            <PowerTable
-              title="Memory power"
-              total={null}
-              resourcesHeaders={resourcesHeaders}
-              resources={powerTable}
-              subHeader="Sub System"
-            />
-          </div>
-          <TableBase header={mainTableHeader} hideAddBtn>
-            {
-            memoryData.map((row, index) => (
-              row.data.enable !== undefined && (
-                <tr key={row.id}>
-                  <td>
-                    <Checkbox
-                      disabled={false}
-                      isChecked={row.data.enable}
-                      label=""
-                      checkHandler={(state) => enableChanged(index, state)}
-                      id={row.id}
-                    />
-                  </td>
-                  <td>{row.data.name}</td>
-                  <Actions
-                    onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
-                  />
-                  <SelectionCell val={row.data.usage} values={memory.usage} />
-                  <SelectionCell val={row.data.memory_type} values={memory.memory_type} />
-                  <td>{row.data.data_rate}</td>
-                  <td>{row.data.width}</td>
-                  <PowerCell val={row.data.consumption.write_bandwidth} />
-                  <PowerCell val={row.data.consumption.read_bandwidth} />
-                  <PowerCell val={row.data.consumption.block_power} />
-                  <td>
-                    {fixed(row.data.consumption.percentage, 0)}
-                    {' %'}
-                  </td>
-                </tr>
-              )
-            ))
-          }
-          </TableBase>
+      <ComponentLabel name="Memory" />
+      <div className="power-and-table-wrapper">
+        <div className="power-table-wrapper">
+          <PowerTable
+            title="Memory power"
+            total={null}
+            resourcesHeaders={resourcesHeaders}
+            resources={powerTable}
+            subHeader="Sub System"
+          />
         </div>
-        {modalOpen && (
+        <TableBase header={mainTableHeader} hideAddBtn>
+          {
+          memoryData.map((row, index) => (
+            row.data.enable !== undefined && (
+              <tr key={row.id}>
+                <td>
+                  <Checkbox
+                    disabled={false}
+                    isChecked={row.data.enable}
+                    label=""
+                    checkHandler={(state) => enableChanged(index, state)}
+                    id={row.id}
+                  />
+                </td>
+                <td>{row.data.name}</td>
+                <Actions
+                  onEditClick={() => { setEditIndex(index); setModalOpen(true); }}
+                />
+                <SelectionCell val={row.data.usage} values={memory.usage} />
+                <SelectionCell val={row.data.memory_type} values={memory.memory_type} />
+                <td>{row.data.data_rate}</td>
+                <td>{row.data.width}</td>
+                <PowerCell val={row.data.consumption.write_bandwidth} />
+                <PowerCell val={row.data.consumption.read_bandwidth} />
+                <PowerCell val={row.data.consumption.block_power} />
+                <td>
+                  {fixed(row.data.consumption.percentage, 0)}
+                  {' %'}
+                </td>
+              </tr>
+            )
+          ))
+        }
+        </TableBase>
+      </div>
+      {modalOpen && (
         <MemoryModal
           closeModal={() => {
             setModalOpen(false);
@@ -161,8 +160,7 @@ function MemoryTable({ device }) {
             width: 32,
           }}
         />
-        )}
-      </div>
+      )}
     </div>
   );
 }

--- a/src/components/Tables/PeripheralsTable.js
+++ b/src/components/Tables/PeripheralsTable.js
@@ -158,7 +158,7 @@ function PeripheralsTable({ device }) {
   }
 
   return (
-    <div className="component-table-head main-border">
+    <div className="component-table-head">
       <div className="main-block">
         <ComponentLabel name="Peripherals" />
         <TableBase header={mainTableHeader} hideAddBtn>

--- a/src/components/Tables/PeripheralsTable.js
+++ b/src/components/Tables/PeripheralsTable.js
@@ -159,58 +159,56 @@ function PeripheralsTable({ device }) {
 
   return (
     <div className="component-table-head">
-      <div className="main-block">
-        <ComponentLabel name="Peripherals" />
-        <TableBase header={mainTableHeader} hideAddBtn>
-          {
-            peripherals.map((row, index) => row.data.map((i, idx) => (
-              i.data !== undefined && (
-              // eslint-disable-next-line react/no-array-index-key
-              <tr key={`${index}.${idx}`}>
-                <td>
-                  <Checkbox
-                    disabled={i.data.enable === undefined}
-                    isChecked={i.data.enable === undefined || i.data.enable}
-                    label=""
-                    checkHandler={(state) => enableChanged(index, idx, state)}
-                    id={index}
-                  />
-                </td>
-                <td className="innerHeader">{i.data.name}</td>
-                <Actions
-                  onEditClick={() => {
-                    setEditIndex({ main: index, inner: idx });
-                    setModalOpen(true);
-                  }}
-                />
-                <SelectionCell val={i.data.usage} values={row.usage} />
-                <SelectionCell val={per.getPerformance(i.data)} values={row.performance} />
-                <td>
-                  {i.data.consumption.calculated_bandwidth}
-                  {' MB/s'}
-                </td>
-                <PowerCell val={i.data.consumption.block_power} />
-                <td>
-                  {fixed(parseFloat(i.data.consumption.percentage), 0)}
-                  {' %'}
-                </td>
-              </tr>
-              )
-            )))
-          }
-        </TableBase>
-        {modalOpen && (
-          <PeripheralsModal
-            closeModal={() => {
-              setModalOpen(false);
-              setEditIndex(null);
-            }}
-            onSubmit={handleSubmit}
-            defaultValue={peripherals[editIndex.main]}
-            index={editIndex.inner}
-          />
-        )}
-      </div>
+      <ComponentLabel name="Peripherals" />
+      <TableBase header={mainTableHeader} hideAddBtn>
+        {
+        peripherals.map((row, index) => row.data.map((i, idx) => (
+          i.data !== undefined && (
+          // eslint-disable-next-line react/no-array-index-key
+          <tr key={`${index}.${idx}`}>
+            <td>
+              <Checkbox
+                disabled={i.data.enable === undefined}
+                isChecked={i.data.enable === undefined || i.data.enable}
+                label=""
+                checkHandler={(state) => enableChanged(index, idx, state)}
+                id={index}
+              />
+            </td>
+            <td className="innerHeader">{i.data.name}</td>
+            <Actions
+              onEditClick={() => {
+                setEditIndex({ main: index, inner: idx });
+                setModalOpen(true);
+              }}
+            />
+            <SelectionCell val={i.data.usage} values={row.usage} />
+            <SelectionCell val={per.getPerformance(i.data)} values={row.performance} />
+            <td>
+              {i.data.consumption.calculated_bandwidth}
+              {' MB/s'}
+            </td>
+            <PowerCell val={i.data.consumption.block_power} />
+            <td>
+              {fixed(parseFloat(i.data.consumption.percentage), 0)}
+              {' %'}
+            </td>
+          </tr>
+          )
+        )))
+        }
+      </TableBase>
+      {modalOpen && (
+      <PeripheralsModal
+        closeModal={() => {
+          setModalOpen(false);
+          setEditIndex(null);
+        }}
+        onSubmit={handleSubmit}
+        defaultValue={peripherals[editIndex.main]}
+        index={editIndex.inner}
+      />
+      )}
     </div>
   );
 }

--- a/src/components/style/ACPUTable.css
+++ b/src/components/style/ACPUTable.css
@@ -1,11 +1,3 @@
-.acpu-container {
-    padding: 6px;
-    padding-top: 0;
-    display: inline-flex;
-    gap: 10px;
-    width: 100%;
-}
-
 .acpu-group {
     display: flex;
     flex-direction: column;

--- a/src/components/style/ComponentTable.css
+++ b/src/components/style/ComponentTable.css
@@ -4,8 +4,8 @@
 
 .table-style {
     overflow: hidden;
-    table-layout: auto;
-    border-collapse: collapse;
+    table-layout: auto; /* cell view */
+    border-collapse: collapse; /* cell view */
     width: 100%;
     border-radius: 8px;
 }

--- a/src/components/style/ComponentTable.css
+++ b/src/components/style/ComponentTable.css
@@ -3,9 +3,12 @@
 }
 
 .table-style {
-    overflow: hidden; /* cut table to nice view */
-    table-layout: auto; /* cell view */
-    border-collapse: collapse; /* cell view */
+    /* cut table to nice view */
+    overflow: hidden;
+    /* cell view */
+    table-layout: auto;
+    /* cell view */
+    border-collapse: collapse;
     width: 100%;
     border-radius: 8px;
 }

--- a/src/components/style/ComponentTable.css
+++ b/src/components/style/ComponentTable.css
@@ -52,4 +52,5 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+    min-width: fit-content;
 }

--- a/src/components/style/ComponentTable.css
+++ b/src/components/style/ComponentTable.css
@@ -3,7 +3,7 @@
 }
 
 .table-style {
-    overflow: hidden;
+    overflow: hidden; /* cut table to nice view */
     table-layout: auto; /* cell view */
     border-collapse: collapse; /* cell view */
     width: 100%;
@@ -49,11 +49,7 @@
 .component-table-head {
     padding: 6px;
     padding-top: 0;
-    display: inline-flex;
-    gap: 10px;
-    width: 100%;
-}
-
-.main-block {
+    display: flex;
+    flex-direction: column;
     width: 100%;
 }

--- a/src/components/style/ComponentsLib.css
+++ b/src/components/style/ComponentsLib.css
@@ -1,8 +1,8 @@
 .layout-head {
     display: flex;
+    flex-direction: row;
     padding: 6px;
     column-gap: 5px;
-    /* border: 1px solid black; */
 }
 
 .component-label-text-center {

--- a/src/style.css
+++ b/src/style.css
@@ -49,7 +49,7 @@
 
 .table-container {
     display: flex;
-    padding-top: 8px;
+    margin-top: 8px;
     min-width: fit-content;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,8 @@
+:root {
+    --border-color: #9c9a9a;
+    --central-size: 54%;
+}
+
 .rpe-head {
     display: flex;
     flex-direction: column;
@@ -15,7 +20,8 @@
 .top-container {
     display: flex;
     flex-direction: column;
-    width: 100%;
+    width: var(--central-size);
+    /* min-width: fit-content; */
 }
 
 .top-l1 {
@@ -51,6 +57,8 @@
     display: flex;
     flex-direction: column;
     row-gap: 10px;
+    width: calc((100% - var(--central-size)) / 2);
+    /* min-width: fit-content; */
 }
 
 .pt-group input,
@@ -130,10 +138,6 @@
     flex-direction: row;
     column-gap: 10px;
     width: 100%;
-}
-
-:root {
-    --border-color: #9c9a9a;
 }
 
 .main-border {

--- a/src/style.css
+++ b/src/style.css
@@ -7,20 +7,29 @@
     display: flex;
     flex-direction: column;
     font-size: 14px;
-    min-width: fit-content;
 }
 
-.app-main-container {
+.top-row-container {
     display: flex;
     flex-direction: row;
     column-gap: 10px;
     min-width: fit-content;
 }
 
-.top-container {
+.main-table-container {
     display: flex;
     flex-direction: column;
     width: var(--central-size);
+    min-width: fit-content;
+}
+
+.table-container {
+    display: flex;
+    margin-top: 8px;
+    overflow: auto;
+    width: 100%;
+    /* TODO, temporary solution to make bottom scroll works */
+    min-width: 1230px;
 }
 
 .top-l1 {
@@ -44,12 +53,6 @@
 
 .top-l2-col2-elem {
     flex-grow: 1;
-}
-
-.table-container {
-    display: flex;
-    margin-top: 8px;
-    min-width: fit-content;
 }
 
 .power-tables {

--- a/src/style.css
+++ b/src/style.css
@@ -7,6 +7,7 @@
     display: flex;
     flex-direction: column;
     font-size: 14px;
+    height: 97vh;
 }
 
 .top-row-container {
@@ -30,6 +31,8 @@
     width: 100%;
     /* TODO, temporary solution to make bottom scroll works */
     min-width: 1230px;
+    height: 100%;
+    min-height: 200px;
 }
 
 .top-l1 {
@@ -48,7 +51,8 @@
     display: flex;
     flex-direction: column;
     width: fit-content;
-    row-gap: 24px; /* should be 8px, for some reason it doen't work, TODO*/
+    /* should be 8px, for some reason it doen't work, TODO */
+    row-gap: 24px;
 }
 
 .top-l2-col2-elem {

--- a/src/style.css
+++ b/src/style.css
@@ -21,7 +21,6 @@
     display: flex;
     flex-direction: column;
     width: var(--central-size);
-    /* min-width: fit-content; */
 }
 
 .top-l1 {
@@ -58,7 +57,6 @@
     flex-direction: column;
     row-gap: 10px;
     width: calc((100% - var(--central-size)) / 2);
-    /* min-width: fit-content; */
 }
 
 .pt-group input,


### PR DESCRIPTION
Updates:
* Top tables layout changed: all three tables width have 54/22/22 % of the width (the number 54 looks better to me then 50% or 60%). Top row of the tables does not change it's height during resize, but the width only.
* Update main layout: now scrolls appears mostly for bottom tables (both vertical and horizontal)
* Improve modal windows (this window allow modify table data): enable scroll bars, use modal component from ant library.
* Cleanup css for tables borders
* improve tables layout: remove main-block element.

Note1. There are still few TODOs for main scroll bars
Note2. Currently tables scroll bars hide Power table. But probably Power table should be visible all the time. 
Note3. Main scroll bars still can appears after make window very small. This will be fixed later.

![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/7203ddbb-962d-4ec6-b168-2ebedbcc3d0b)

![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/b8f743f3-6e54-4337-8ad5-bdcff68ac688)

![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/b4b9036b-decf-4953-a902-8a8f7bd26cfe)
