### PR TITLE
Make memory component optional

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -58,6 +58,8 @@ function App() {
   const { setClocks } = useClockSelection();
   const { updateGlobalState } = useGlobalState();
   const { updateTotalPower } = useSocTotalPower();
+  const [peripherals, setPeripherals] = React.useState(null);
+  const [memoryEnable, setMemoryEnable] = React.useState(true);
 
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   const showModal = () => {
@@ -104,6 +106,10 @@ function App() {
     setDevice(newDevice);
     updateGlobalState(newDevice);
     updateTotalPower(newDevice);
+    server.GET(server.api.fetch(server.Elem.peripherals, newDevice), (data) => {
+      setMemoryEnable(data.memory !== undefined);
+      setPeripherals(data);
+    });
     if (newDevice !== null) {
       server.GET(server.api.consumption(server.Elem.clocking, newDevice), (data) => {
         const total = data.total_clock_block_power
@@ -162,6 +168,7 @@ function App() {
             <SOCComponent
               device={device}
               setOpenedTable={setOpenedTable}
+              peripherals={peripherals}
             />
             <div className="top-l2-col2">
               <div className="top-l2-col2-elem">
@@ -174,9 +181,13 @@ function App() {
                   tableOpen={setOpenedTable}
                 />
               </div>
-              <div onClick={() => setOpenedTable(Table.Memory)}>
-                <MemoryComponent device={device} />
-              </div>
+              {
+                memoryEnable && (
+                <div onClick={() => setOpenedTable(Table.Memory)}>
+                  <MemoryComponent device={device} peripherals={peripherals} />
+                </div>
+                )
+              }
             </div>
           </div>
         </div>
@@ -272,7 +283,7 @@ function App() {
         }
         {
         openedTable === Table.Memory
-        && <MemoryTable device={device} />
+        && <MemoryTable device={device} peripherals={peripherals} />
         }
         {
         openedTable === Table.DMA

--- a/src/components/SOCComponent.js
+++ b/src/components/SOCComponent.js
@@ -13,7 +13,7 @@ import { useGlobalState } from '../GlobalStateProvider';
 
 import './style/SOCTable.css';
 
-function SOCTable({ device, setOpenedTable }) {
+function SOCComponent({ device, setOpenedTable, peripherals }) {
   const { selectedItem } = useSelection();
   const {
     power, dynamicPower, staticPower,
@@ -63,7 +63,7 @@ function SOCTable({ device, setOpenedTable }) {
           <DMAComponent device={device} />
         </div>
         <div className="top-l2-col1-row2-elem" onClick={() => setOpenedTable(Table.Connectivity)}>
-          <ConnectivityComponent device={device} />
+          <ConnectivityComponent device={device} peripherals={peripherals} />
         </div>
       </div>
       <div onClick={() => setOpenedTable(Table.Peripherals)}>
@@ -73,13 +73,13 @@ function SOCTable({ device, setOpenedTable }) {
   );
 }
 
-SOCTable.propTypes = {
+SOCComponent.propTypes = {
   device: PropTypes.string,
   setOpenedTable: PropTypes.func.isRequired,
 };
 
-SOCTable.defaultProps = {
+SOCComponent.defaultProps = {
   device: null,
 };
 
-export default SOCTable;
+export default SOCComponent;

--- a/src/components/Tables/MemoryTable.js
+++ b/src/components/Tables/MemoryTable.js
@@ -15,7 +15,7 @@ import { ComponentLabel } from '../ComponentsLib';
 
 import '../style/ComponentTable.css';
 
-function MemoryTable({ device }) {
+function MemoryTable({ device, peripherals }) {
   const [dev, setDev] = React.useState(null);
   const [editIndex, setEditIndex] = React.useState(null);
   const [modalOpen, setModalOpen] = React.useState(false);
@@ -55,10 +55,8 @@ function MemoryTable({ device }) {
   if (dev !== device) {
     setDev(device);
     if (device !== null) {
-      server.GET(server.api.fetch(server.Elem.peripherals, device), (data) => {
-        setHref(data.memory);
-        fetchData(data.memory);
-      });
+      setHref(peripherals.memory);
+      fetchData(peripherals.memory);
     }
   }
 
@@ -154,6 +152,7 @@ function MemoryTable({ device }) {
 
 MemoryTable.propTypes = {
   device: PropTypes.string,
+  peripherals: PropTypes.oneOfType([PropTypes.object]).isRequired,
 };
 
 MemoryTable.defaultProps = {

--- a/src/style.css
+++ b/src/style.css
@@ -51,12 +51,14 @@
     display: flex;
     flex-direction: column;
     width: fit-content;
-    /* should be 8px, for some reason it doen't work, TODO */
-    row-gap: 24px;
+    row-gap: 8px;
+    height: 100%;
 }
 
 .top-l2-col2-elem {
-    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 .power-tables {


### PR DESCRIPTION
Change list:
* Make Memory component optional that depends on data received from peripherals API. 
* Fixed FPGA component layout.

Note. Still need update summary table for memory.

![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/25714900-bc98-4d28-acc5-fe64b251dfda)
