### PR TITLE
Add possibility for some blocks display as not available

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -236,7 +236,7 @@ function App() {
         }
         {
         openedTable === Table.Connectivity
-        && <ConnectivityTable device={device} />
+        && <ConnectivityTable device={device} peripherals={peripherals} />
         }
         {
         openedTable === Table.Memory
@@ -248,7 +248,7 @@ function App() {
         }
         {
         openedTable === Table.Peripherals
-        && <PeripheralsTable device={device} />
+        && <PeripheralsTable device={device} peripheralsUrl={peripherals} />
         }
         {
         openedTable === Table.Summary

--- a/src/components/CPUComponent.js
+++ b/src/components/CPUComponent.js
@@ -8,7 +8,7 @@ const text = [
   'Endpoint 1', 'Endpoint 2', 'Endpoint 3', 'Endpoint 4',
 ];
 
-function CPUComponent({
+export function CPUComponent({
   title, power, percent = 0, name, endpointText = text, ep0 = 0, ep1 = 0, ep2 = 0, ep3 = 0,
 }) {
   return (
@@ -59,6 +59,19 @@ function CPUComponent({
   );
 }
 
+export function CPUComponentDisabled({ title }) {
+  return (
+    <div className="cpu-component-top">
+      <div className="cpu-component-l1">
+        <div className="cpu-component-title">{title}</div>
+      </div>
+      <div className="cpu-component-l2">
+        <div className="cpu-component-power grayed-text">Not available</div>
+      </div>
+    </div>
+  );
+}
+
 CPUComponent.propTypes = {
   title: PropTypes.string.isRequired,
   power: PropTypes.number.isRequired,
@@ -74,5 +87,3 @@ CPUComponent.propTypes = {
 CPUComponent.defaultProps = {
   endpointText: text,
 };
-
-export default CPUComponent;

--- a/src/components/MemoryComponent.js
+++ b/src/components/MemoryComponent.js
@@ -105,10 +105,12 @@ function MemoryComponent({ device, peripherals }) {
 
 MemoryComponent.propTypes = {
   device: PropTypes.string,
+  peripherals: PropTypes.oneOfType([PropTypes.object]),
 };
 
 MemoryComponent.defaultProps = {
   device: null,
+  peripherals: null,
 };
 
 export default MemoryComponent;

--- a/src/components/SOCComponent.js
+++ b/src/components/SOCComponent.js
@@ -6,21 +6,14 @@ import TitleComponent from './TitleComponent';
 import ABCPUComponent from './ABCPUComponent';
 import DMAComponent from './DMAComponent';
 import ConnectivityComponent from './ConnectivityComponent';
-import { useSelection } from '../SelectionProvider';
 import { useSocTotalPower } from '../SOCTotalPowerProvider';
-import { State } from './ComponentsLib';
 import { useGlobalState } from '../GlobalStateProvider';
 
 import './style/SOCTable.css';
 
 function SOCComponent({ device, setOpenedTable, peripherals }) {
-  const { selectedItem } = useSelection();
   const { totalConsumption } = useSocTotalPower();
   const { socState } = useGlobalState();
-
-  function getBaseName(item) {
-    return (selectedItem === item) ? 'clickable selected' : 'clickable';
-  }
 
   const processingComplex = totalConsumption.processing_complex;
 
@@ -31,26 +24,26 @@ function SOCComponent({ device, setOpenedTable, peripherals }) {
     <div className="top-l2-col1">
       <div className="top-l2-col1-row1">
         <div className="top-l2-col1-row1-elem" onClick={() => setOpenedTable(Table.ACPU)}>
-          <State messages={socState.acpu} baseClass={getBaseName('ACPU')}>
-            <ABCPUComponent
-              device={device}
-              title="ACPU"
-              index="acpu"
-              power={acpu ? acpu.power : 0}
-              percent={acpu ? acpu.percentage : 0}
-            />
-          </State>
+          <ABCPUComponent
+            device={device}
+            title="ACPU"
+            index="acpu"
+            power={acpu ? acpu.power : 0}
+            percent={acpu ? acpu.percentage : 0}
+            messages={socState.acpu}
+            peripherals={peripherals}
+          />
         </div>
         <div className="top-l2-col1-row1-elem" onClick={() => setOpenedTable(Table.BCPU)}>
-          <State messages={socState.bcpu} baseClass={getBaseName('BCPU')}>
-            <ABCPUComponent
-              device={device}
-              title="BCPU"
-              index="bcpu"
-              power={bcpu ? bcpu.power : 0}
-              percent={bcpu ? bcpu.percentage : 0}
-            />
-          </State>
+          <ABCPUComponent
+            device={device}
+            title="BCPU"
+            index="bcpu"
+            power={bcpu ? bcpu.power : 0}
+            percent={bcpu ? bcpu.percentage : 0}
+            messages={socState.bcpu}
+            peripherals={peripherals}
+          />
         </div>
         <div className="top-l2-col1-row1-elem-text">
           <TitleComponent
@@ -73,7 +66,7 @@ function SOCComponent({ device, setOpenedTable, peripherals }) {
       </div>
       <div className="top-l2-col1-row2">
         <div className="top-l2-col1-row2-elem" onClick={() => setOpenedTable(Table.DMA)}>
-          <DMAComponent device={device} />
+          <DMAComponent device={device} peripherals={peripherals} />
         </div>
         <div className="top-l2-col1-row2-elem" onClick={() => setOpenedTable(Table.Connectivity)}>
           <ConnectivityComponent device={device} peripherals={peripherals} />

--- a/src/components/Tables/ConnectivityTable.js
+++ b/src/components/Tables/ConnectivityTable.js
@@ -15,7 +15,7 @@ import { useClockSelection } from '../../ClockSelectionProvider';
 
 import '../style/ACPUTable.css';
 
-function ConnectivityTable({ device }) {
+function ConnectivityTable({ device, peripherals }) {
   const [dev, setDev] = React.useState(null);
   const [editIndex, setEditIndex] = React.useState(null);
   const [modalOpen, setModalOpen] = React.useState(false);
@@ -52,12 +52,21 @@ function ConnectivityTable({ device }) {
   }
 
   function fetchData() {
-    server.GET(server.api.fetch(server.Elem.peripherals, device), (data) => {
-      const link = data.fpga_complex[0].href;
+    if (peripherals && peripherals.fpga_complex) {
+      const link = peripherals.fpga_complex[0].href;
       setHref(link);
       fetchConnectivityData(link);
-    });
+    } else {
+      setEndpoints([]);
+      setHref('');
+      setAddButtonDisable(true);
+    }
   }
+
+  React.useEffect(() => {
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [peripherals]);
 
   if (dev !== device) {
     setDev(device);

--- a/src/components/Tables/PeripheralsTable.js
+++ b/src/components/Tables/PeripheralsTable.js
@@ -10,7 +10,7 @@ import { ComponentLabel, Checkbox } from '../ComponentsLib';
 
 import '../style/ComponentTable.css';
 
-function PeripheralsTable({ device }) {
+function PeripheralsTable({ device, peripheralsUrl }) {
   const [dev, setDev] = React.useState(null);
   const [editIndex, setEditIndex] = React.useState(null);
   const [modalOpen, setModalOpen] = React.useState(false);
@@ -108,19 +108,13 @@ function PeripheralsTable({ device }) {
   }
 
   const fetchData = (deviceId) => {
-    if (deviceId !== null) {
-      server.GET(server.api.fetch(server.Elem.peripherals, deviceId), (data) => {
-        const peripheralData = data;
-        delete peripheralData.dma;
-        delete peripheralData.memory;
-        delete peripheralData.acpu;
-        delete peripheralData.bcpu;
-        Object.entries(peripheralData).forEach((elem) => {
-          const [key, values] = elem;
-          Object.entries(values).forEach((val) => {
-            const [, obj] = val;
-            fetchPeripherals(deviceId, key, obj.href);
-          });
+    if (deviceId !== null && peripheralsUrl !== null) {
+      Object.entries(peripheralsUrl).forEach((elem) => {
+        const [key, values] = elem;
+        if (key === 'dma' || key === 'memory' || key === 'acpu' || key === 'bcpu') return;
+        Object.entries(values).forEach((val) => {
+          const [, obj] = val;
+          fetchPeripherals(deviceId, key, obj.href);
         });
       });
     }

--- a/src/components/style/FpgaComponent.css
+++ b/src/components/style/FpgaComponent.css
@@ -28,6 +28,12 @@
     height: 100%;
 }
 
+.disabled {
+    padding: 5px;
+    height: 100%;
+    background-color: #bebebe;
+}
+
 #io {
     width: 100%;
 }

--- a/src/components/style/Peripherals.css
+++ b/src/components/style/Peripherals.css
@@ -36,6 +36,13 @@
     padding: 4px;
 }
 
+.periph-rowx-empty {
+    width: 100%;
+    padding: 4px;
+    background-color: #c9c7c7;
+    min-height: 20px;
+}
+
 .periph-internal-font {
     color: #727e74;
     font-size: smaller;


### PR DESCRIPTION
Change list:
* Prepare SOC blocks for possible cases then no such peripheral in the device.
* Show grayed component
* Such block can't be selected.

Items in progress:
* Power table need to update according to the components existence.
* When user click to disabled block, need to prevent corresponding table opening 

![image](https://github.com/os-fpga/rapid_power_estimator/assets/6624470/ce1d1122-d768-452b-a1f8-162008dea7b1)
