### PR TITLE
Fixed issue when fetch attributes failed for non-default port

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -68,7 +68,7 @@ function App() {
   const { toggleItemSelection } = useSelection();
   const [preferencesChanged, setPreferencesChanged] = React.useState(false);
   const { setClocks } = useClockSelection();
-  const { updateGlobalState } = useGlobalState();
+  const { updateGlobalState, fetchAttributes } = useGlobalState();
   const { updateTotalPower } = useSocTotalPower();
   const [peripherals, setPeripherals] = React.useState([]);
   const [memoryEnable, setMemoryEnable] = React.useState(true);
@@ -157,6 +157,7 @@ function App() {
         setConfig(data);
         setAutoSave(data.autoSave);
         server.setPort(data.port, setDevices);
+        fetchAttributes();
       });
       window.ipcAPI.ipcRendererOn('projectData', (event, data) => {
         if (data.action === 'new') server.POST(server.projectClose(), {}, fetchProjectData);

--- a/src/GlobalStateProvider.js
+++ b/src/GlobalStateProvider.js
@@ -1,6 +1,5 @@
 import React, {
   createContext, useContext, useState, useMemo,
-  useEffect,
 } from 'react';
 import * as server from './utils/serverAPI';
 
@@ -42,10 +41,6 @@ export function GlobalStateProvider({ children, fetch }) { // TODO temp fix for 
   const acpuNamesLocal = [];
   const bcpuNamesLocal = [];
   const connectivityNamesLocal = [];
-
-  useEffect(() => {
-    fetch(server.attributes(), (attr) => setAttributes(attr));
-  }, [fetch]);
 
   function fetchPort(device, link, port, key) {
     server.GET(server.peripheralPath(device, `${link}/${port.href}`), (data) => {
@@ -135,6 +130,10 @@ export function GlobalStateProvider({ children, fetch }) { // TODO temp fix for 
     return (found === undefined) ? [] : found.options;
   }
 
+  function fetchAttributes() {
+    fetch(server.attributes(), (attr) => setAttributes(attr));
+  }
+
   const values = useMemo(() => ({
     updateGlobalState,
     clockingState,
@@ -148,6 +147,7 @@ export function GlobalStateProvider({ children, fetch }) { // TODO temp fix for 
     acpuNames,
     bcpuNames,
     connectivityNames,
+    fetchAttributes,
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }), [bramState, clockingState, dspState, fleState, ioState, socState]);
 


### PR DESCRIPTION
 ### Motivate of the pull request
 - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
 - [ ] Breaking new feature. If so, please describe details in the description part.

### Describe the technical details
Fetch attributes fires before the right port was set. 
The fix is make sure fetching attributes fires after the port setup.

 ### Which part of the code base require a change
 <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
 - [ ] Frontend: <Specify frontend components>
 - [ ] Backend: <Specify backend components>
 - [ ] Library: <Specify the library name, e.g. npm packages>
 - [ ] Plug-in: <Specify the plugin name, e.g. Webpack, jtest>
 - [ ] Documentation
 - [ ] Regression tests
 - [ ] Continuous Integration (CI) scripts