### PR TITLE
Move Q/SPI peripheral power data into JSON power config file

### DIFF
--- a/backend/etc/devices/mpw1/power_data.json
+++ b/backend/etc/devices/mpw1/power_data.json
@@ -8,6 +8,7 @@
         { "$ref": "fabric_le.json" },
         { "$ref": "bram.json" },
         { "$ref": "io.json" },
-        { "$ref": "uart.json" }
+        { "$ref": "uart.json" },
+        { "$ref": "qspi.json" }
     ]
 }

--- a/backend/etc/devices/mpw1/qspi.json
+++ b/backend/etc/devices/mpw1/qspi.json
@@ -1,0 +1,8 @@
+{
+    "type": "spi",
+    "coeffs": [
+        { "name": "QSPI_CLK_FACTOR"      , "value": 0.0000154995864661654 },
+        { "name": "QSPI_SWITCHING_FACTOR", "value": 0.00156512937507589   },
+        { "name": "QSPI_IO_FACTOR"       , "value": 0.0001270766          }
+    ]
+}

--- a/backend/submodule/rs_device_resources.py
+++ b/backend/submodule/rs_device_resources.py
@@ -540,13 +540,13 @@ class RsDeviceResources:
         return 0.00004367522
 
     def get_QSPI_CLK_FACTOR(self) -> float:
-        return 0.0000154995864661654
+        return self.powercfg.get_coeff(ElementType.SPI, 'QSPI_CLK_FACTOR')
 
     def get_QSPI_SWITCHING_FACTOR(self) -> float:
-        return 0.00156512937507589
+        return self.powercfg.get_coeff(ElementType.SPI, 'QSPI_SWITCHING_FACTOR')
 
     def get_QSPI_IO_FACTOR(self) -> float:
-        return 0.0001270766
+        return self.powercfg.get_coeff(ElementType.SPI, 'QSPI_IO_FACTOR')
 
     def get_USB2_CLK_FACTOR(self) -> float:
         return 0.0000261772947994987

--- a/backend/submodule/rs_power_config.py
+++ b/backend/submodule/rs_power_config.py
@@ -72,6 +72,7 @@ class ElementType(Enum):
     IO_HR_2_5V = 'io_hr_2_5v'
     IO_HR_3_3V = 'io_hr_3_3v'
     UART = 'uart'
+    SPI = 'spi'
 
 class ScenarioType(Enum):
     TYPICAL = 'typical'

--- a/tests/test_rs_device_resources.py
+++ b/tests/test_rs_device_resources.py
@@ -91,7 +91,10 @@ def test_get_clock_not_found(device_resources):
 @pytest.mark.parametrize("method_name, element_type, coef_name, coef_value", [
     ("get_UART_CLK_FACTOR", ElementType.UART, "UART_CLK_FACTOR", 0.1234),
     ("get_UART_SWITCHING_FACTOR", ElementType.UART, "UART_SWITCHING_FACTOR", 0.4567),
-    ("get_UART_IO_FACTOR", ElementType.UART, "UART_IO_FACTOR", 123.456)
+    ("get_UART_IO_FACTOR", ElementType.UART, "UART_IO_FACTOR", 123.456),
+    ("get_QSPI_CLK_FACTOR", ElementType.SPI, "QSPI_CLK_FACTOR", 0.1234),
+    ("get_QSPI_SWITCHING_FACTOR", ElementType.SPI, "QSPI_SWITCHING_FACTOR", 0.4567),
+    ("get_QSPI_IO_FACTOR", ElementType.SPI, "QSPI_IO_FACTOR", 123.456)
 ])
 def test_power_coeff_method(mock_device, method_name, element_type, coef_name, coef_value):
     with patch('submodule.rs_device_resources.RsPowerConfig') as MockRsPowerConfig:


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> Change
> - Migrate hardcoded q/spi peripheral power calculation coefficient to JSON power config file

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Frontend: <Specify frontend components>
> - [x] Backend: Power Config module
> - [ ] Library: <Specify the library name, e.g. npm packages>
> - [ ] Plug-in: <Specify the plugin name, e.g. Webpack, jtest>
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continuous Integration (CI) scripts