### PR TITLE
Move JTAG peripheral power data into JSON power config file

### DIFF
--- a/backend/etc/devices/mpw1/jtag.json
+++ b/backend/etc/devices/mpw1/jtag.json
@@ -1,0 +1,8 @@
+{
+    "type": "jtag",
+    "coeffs": [
+        { "name": "JTAG_CLK_FACTOR"      , "value": 0.000407953336466165 },
+        { "name": "JTAG_SWITCHING_FACTOR", "value": 0.000264495634397032 },
+        { "name": "JTAG_IO_FACTOR"       , "value": 0.00004367522        }
+    ]
+}

--- a/backend/etc/devices/mpw1/power_data.json
+++ b/backend/etc/devices/mpw1/power_data.json
@@ -11,6 +11,7 @@
         { "$ref": "uart.json" },
         { "$ref": "qspi.json" },
         { "$ref": "acpu.json" },
-        { "$ref": "bcpu.json" }
+        { "$ref": "bcpu.json" },
+        { "$ref": "jtag.json" }
     ]
 }

--- a/backend/submodule/rs_device_resources.py
+++ b/backend/submodule/rs_device_resources.py
@@ -527,13 +527,13 @@ class RsDeviceResources:
         return 0.000056634
 
     def get_JTAG_CLK_FACTOR(self) -> float:
-        return 0.000407953336466165
+        return self.powercfg.get_coeff(ElementType.JTAG, 'JTAG_CLK_FACTOR')
 
     def get_JTAG_SWITCHING_FACTOR(self) -> float:
-        return 0.000264495634397032
+        return self.powercfg.get_coeff(ElementType.JTAG, 'JTAG_SWITCHING_FACTOR')
 
     def get_JTAG_IO_FACTOR(self) -> float:
-        return 0.00004367522
+        return self.powercfg.get_coeff(ElementType.JTAG, 'JTAG_IO_FACTOR')
 
     def get_QSPI_CLK_FACTOR(self) -> float:
         return self.powercfg.get_coeff(ElementType.SPI, 'QSPI_CLK_FACTOR')

--- a/backend/submodule/rs_power_config.py
+++ b/backend/submodule/rs_power_config.py
@@ -74,6 +74,7 @@ class ElementType(Enum):
     UART = 'uart'
     SPI = 'spi'
     BCPU = 'bcpu'
+    JTAG = 'jtag'
 
 class ScenarioType(Enum):
     TYPICAL = 'typical'

--- a/tests/test_rs_device_resources.py
+++ b/tests/test_rs_device_resources.py
@@ -102,7 +102,10 @@ def test_get_clock_not_found(device_resources):
     ("get_BCPU_CLK_FACTOR", ElementType.BCPU, "BCPU_CLK_FACTOR", 1111.2222),
     ("get_BCPU_LOW_LOAD_FACTOR", ElementType.BCPU, "BCPU_LOW_LOAD_FACTOR", 0.456),
     ("get_BCPU_MEDIUM_LOAD_FACTOR", ElementType.BCPU, "BCPU_MEDIUM_LOAD_FACTOR", 0.123),
-    ("get_BCPU_HIGH_LOAD_FACTOR", ElementType.BCPU, "BCPU_HIGH_LOAD_FACTOR", 123.456)
+    ("get_BCPU_HIGH_LOAD_FACTOR", ElementType.BCPU, "BCPU_HIGH_LOAD_FACTOR", 123.456),
+    ("get_JTAG_CLK_FACTOR", ElementType.JTAG, "JTAG_CLK_FACTOR", 0.4321),
+    ("get_JTAG_SWITCHING_FACTOR", ElementType.JTAG, "JTAG_SWITCHING_FACTOR", 0.8765),
+    ("get_JTAG_IO_FACTOR", ElementType.JTAG, "JTAG_IO_FACTOR", 85.9087),
 ])
 def test_power_coeff_method(mock_device, method_name, element_type, coef_name, coef_value):
     with patch('submodule.rs_device_resources.RsPowerConfig') as MockRsPowerConfig:


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> Change:
> - Migrate hardcoded JTAG peripheral power calculation coefficient to external JSON power config file

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Frontend: <Specify frontend components>
> - [x] Backend: Power Config Module
> - [ ] Library: <Specify the library name, e.g. npm packages>
> - [ ] Plug-in: <Specify the plugin name, e.g. Webpack, jtest>
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continuous Integration (CI) scripts