### PR TITLE
Move I2C peripheral power data into JSON power config file

### DIFF
--- a/backend/etc/devices/mpw1/i2c.json
+++ b/backend/etc/devices/mpw1/i2c.json
@@ -1,0 +1,8 @@
+{
+    "type": "i2c",
+    "coeffs": [
+        { "name": "I2C_CLK_FACTOR"      , "value": 0.0000180345864661654 },
+        { "name": "I2C_SWITCHING_FACTOR", "value": 0.0000846668045655417 },
+        { "name": "I2C_IO_FACTOR"       , "value": 0.000056634           }
+    ]
+}

--- a/backend/etc/devices/mpw1/power_data.json
+++ b/backend/etc/devices/mpw1/power_data.json
@@ -12,6 +12,7 @@
         { "$ref": "qspi.json" },
         { "$ref": "acpu.json" },
         { "$ref": "bcpu.json" },
-        { "$ref": "jtag.json" }
+        { "$ref": "jtag.json" },
+        { "$ref": "i2c.json" }
     ]
 }

--- a/backend/submodule/rs_device_resources.py
+++ b/backend/submodule/rs_device_resources.py
@@ -518,13 +518,13 @@ class RsDeviceResources:
         return self.powercfg.get_coeff(ElementType.ACPU, 'ACPU_HIGH_LOAD_FACTOR')
 
     def get_I2C_CLK_FACTOR(self) -> float:
-        return 0.0000180345864661654
+        return self.powercfg.get_coeff(ElementType.I2C, 'I2C_CLK_FACTOR')
 
     def get_I2C_SWITCHING_FACTOR(self) -> float:
-        return 0.0000846668045655417
+        return self.powercfg.get_coeff(ElementType.I2C, 'I2C_SWITCHING_FACTOR')
 
     def get_I2C_IO_FACTOR(self) -> float:
-        return 0.000056634
+        return self.powercfg.get_coeff(ElementType.I2C, 'I2C_IO_FACTOR')
 
     def get_JTAG_CLK_FACTOR(self) -> float:
         return self.powercfg.get_coeff(ElementType.JTAG, 'JTAG_CLK_FACTOR')

--- a/backend/submodule/rs_power_config.py
+++ b/backend/submodule/rs_power_config.py
@@ -75,6 +75,7 @@ class ElementType(Enum):
     SPI = 'spi'
     BCPU = 'bcpu'
     JTAG = 'jtag'
+    I2C = 'i2c'
 
 class ScenarioType(Enum):
     TYPICAL = 'typical'

--- a/tests/test_rs_device_resources.py
+++ b/tests/test_rs_device_resources.py
@@ -106,6 +106,9 @@ def test_get_clock_not_found(device_resources):
     ("get_JTAG_CLK_FACTOR", ElementType.JTAG, "JTAG_CLK_FACTOR", 0.4321),
     ("get_JTAG_SWITCHING_FACTOR", ElementType.JTAG, "JTAG_SWITCHING_FACTOR", 0.8765),
     ("get_JTAG_IO_FACTOR", ElementType.JTAG, "JTAG_IO_FACTOR", 85.9087),
+    ("get_I2C_CLK_FACTOR", ElementType.I2C, "I2C_CLK_FACTOR", 0.4321),
+    ("get_I2C_SWITCHING_FACTOR", ElementType.I2C, "I2C_SWITCHING_FACTOR", 0.8765),
+    ("get_I2C_IO_FACTOR", ElementType.I2C, "I2C_IO_FACTOR", 85.9087),
 ])
 def test_power_coeff_method(mock_device, method_name, element_type, coef_name, coef_value):
     with patch('submodule.rs_device_resources.RsPowerConfig') as MockRsPowerConfig:


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> Change:
> - Migrate hardcoded I2C peripheral power calculation coefficient to external JSON power config file

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Frontend: <Specify frontend components>
> - [x] Backend: Power Config Module
> - [ ] Library: <Specify the library name, e.g. npm packages>
> - [ ] Plug-in: <Specify the plugin name, e.g. Webpack, jtest>
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continuous Integration (CI) scripts