### PR TITLE
Move USB2 peripheral power data into JSON power config file

### DIFF
--- a/backend/etc/devices/mpw1/power_data.json
+++ b/backend/etc/devices/mpw1/power_data.json
@@ -13,6 +13,7 @@
         { "$ref": "acpu.json" },
         { "$ref": "bcpu.json" },
         { "$ref": "jtag.json" },
-        { "$ref": "i2c.json" }
+        { "$ref": "i2c.json" },
+        { "$ref": "usb2.json" }
     ]
 }

--- a/backend/etc/devices/mpw1/usb2.json
+++ b/backend/etc/devices/mpw1/usb2.json
@@ -1,0 +1,8 @@
+{
+    "type": "usb2",
+    "coeffs": [
+        { "name": "USB2_CLK_FACTOR"      , "value": 0.0000261772947994987 },
+        { "name": "USB2_SWITCHING_FACTOR", "value": 0.0000440759304744493 },
+        { "name": "USB2_IO_FACTOR"       , "value": 0.00166056666666667   }
+    ]
+}

--- a/backend/submodule/rs_device_resources.py
+++ b/backend/submodule/rs_device_resources.py
@@ -545,13 +545,13 @@ class RsDeviceResources:
         return self.powercfg.get_coeff(ElementType.SPI, 'QSPI_IO_FACTOR')
 
     def get_USB2_CLK_FACTOR(self) -> float:
-        return 0.0000261772947994987
+        return self.powercfg.get_coeff(ElementType.USB2, 'USB2_CLK_FACTOR')
 
     def get_USB2_SWITCHING_FACTOR(self) -> float:
-        return 0.0000440759304744493
+        return self.powercfg.get_coeff(ElementType.USB2, 'USB2_SWITCHING_FACTOR')
 
     def get_USB2_IO_FACTOR(self) -> float:
-        return 0.00166056666666667
+        return self.powercfg.get_coeff(ElementType.USB2, 'USB2_IO_FACTOR')
 
     def get_GIGE_CLK_FACTOR(self) -> float:
         return 0.000124771586466165

--- a/backend/submodule/rs_power_config.py
+++ b/backend/submodule/rs_power_config.py
@@ -76,6 +76,7 @@ class ElementType(Enum):
     BCPU = 'bcpu'
     JTAG = 'jtag'
     I2C = 'i2c'
+    USB2 = 'usb2'
 
 class ScenarioType(Enum):
     TYPICAL = 'typical'

--- a/tests/test_rs_device_resources.py
+++ b/tests/test_rs_device_resources.py
@@ -109,6 +109,9 @@ def test_get_clock_not_found(device_resources):
     ("get_I2C_CLK_FACTOR", ElementType.I2C, "I2C_CLK_FACTOR", 0.4321),
     ("get_I2C_SWITCHING_FACTOR", ElementType.I2C, "I2C_SWITCHING_FACTOR", 0.8765),
     ("get_I2C_IO_FACTOR", ElementType.I2C, "I2C_IO_FACTOR", 85.9087),
+    ("get_USB2_CLK_FACTOR", ElementType.USB2, "USB2_CLK_FACTOR", 0.4321),
+    ("get_USB2_SWITCHING_FACTOR", ElementType.USB2, "USB2_SWITCHING_FACTOR", 0.8765),
+    ("get_USB2_IO_FACTOR", ElementType.USB2, "USB2_IO_FACTOR", 85.9087),
 ])
 def test_power_coeff_method(mock_device, method_name, element_type, coef_name, coef_value):
     with patch('submodule.rs_device_resources.RsPowerConfig') as MockRsPowerConfig:


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> Change:
> - Migrate hardcoded U2B2 peripheral power calculation coefficient to external JSON power config file

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Frontend: <Specify frontend components>
> - [x] Backend: Power Config module
> - [ ] Library: <Specify the library name, e.g. npm packages>
> - [ ] Plug-in: <Specify the plugin name, e.g. Webpack, jtest>
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continuous Integration (CI) scripts