### PR TITLE
Fix PWM compute object use wrong prop & output child classes

### DIFF
--- a/backend/submodule/peripherals.py
+++ b/backend/submodule/peripherals.py
@@ -582,8 +582,8 @@ class Pwm0(ComputeObject):
     def __post_init__(self) -> None:
         self.get_context().set_usage(Peripherals_Usage.App)
         self.get_context().set_enable(True)
-        self.properties = Gpio0.properties_(io_used=0, io_standard=GpioStandard.SSTL_1_8V_Class_I_HR)
-        self.output = Gpio0.output_()
+        self.properties = Pwm0.properties_(io_used=0, io_standard=GpioStandard.SSTL_1_8V_Class_I_HR)
+        self.output = Pwm0.output_()
         self.messages: List[RsMessage] = []
 
     def get_properties(self) -> Dict[str, Any]:


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> Change:
> - Issue: The Pwm0 class in peripherals module uses wrong child classes (properties_ & output_) from Gpio0 classes. 
> - Fix: Use these child classes defined within Pwm0 class itself.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Frontend: <Specify frontend components>
> - [x] Backend: PWM Peripheral Module
> - [ ] Library: <Specify the library name, e.g. npm packages>
> - [ ] Plug-in: <Specify the plugin name, e.g. Webpack, jtest>
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continuous Integration (CI) scripts