### PR TITLE
Fixing the RPE crash error when editing GPIO Peripheral in popup dialog

### DIFF
--- a/src/components/ModalWindows/PeripheralsModal.js
+++ b/src/components/ModalWindows/PeripheralsModal.js
@@ -1,39 +1,60 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { FieldType, getPerformance } from '../../utils/common';
 import ModalWindow from './ModalWindow';
+
+function useDisableEnterKey() {
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+}
+
+function getFields(defaultValue, index) {
+  return [
+    {
+      fieldType: FieldType.select,
+      id: 'usage',
+      text: 'Usage',
+      value: defaultValue.data[index].data.usage,
+      values: defaultValue.usage,
+    },
+    {
+      fieldType: FieldType.select,
+      id: defaultValue.performance_id,
+      text: 'Performance',
+      value: getPerformance(defaultValue.data[index].data),
+      values: defaultValue.performance,
+    },
+    {
+      disable: !defaultValue.io_used,
+      fieldType: FieldType.number,
+      id: 'io_used',
+      text: 'IO Used',
+      value: defaultValue.data.io_used,
+    },
+  ];
+}
 
 function PeripheralsModal({
   closeModal, onSubmit, defaultValue, index,
 }) {
+  useDisableEnterKey();
+
   return (
     <ModalWindow
       closeModal={closeModal}
       onSubmit={onSubmit}
       defaultValue={defaultValue.data[index].data}
       title={defaultValue.data[index].data.name}
-      fields={[
-        {
-          fieldType: FieldType.select,
-          id: 'usage',
-          text: 'Usage',
-          value: defaultValue.data[index].data.usage,
-          values: defaultValue.usage,
-        },
-        {
-          fieldType: FieldType.select,
-          id: defaultValue.performance_id,
-          text: 'Performance',
-          value: getPerformance(defaultValue.data[index].data),
-          values: defaultValue.performance,
-        },
-        {
-          disable: !defaultValue.io_used,
-          fieldType: FieldType.number,
-          id: 'io_used',
-          text: 'IO Used',
-          value: defaultValue.data.io_used,
-        },
-      ]}
+      fields={getFields(defaultValue, index)}
     />
   );
 }


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details - 

Fixing issue where pressing the Enter key in the "IO Used" field of the Peripherals modal causes the screen to turn white and reset to the initial stage.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Frontend: <Specify frontend components>PeripheralModal.js
> - [ ] Backend: <Specify backend components>
> - [ ] Library: <Specify the library name, e.g. npm packages>
> - [ ] Plug-in: <Specify the plugin name, e.g. Webpack, jtest>
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continuous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break backward-compatibility. If so, please list who may be influenced.
