### PR TITLE
Adding folder for Tables tests and adding a sample jest test for APCUTable.js

### DIFF
--- a/src/tests/Tables_tests/ACPUTable.test.js
+++ b/src/tests/Tables_tests/ACPUTable.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ACPUTable from '../../components/Tables/ACPUTable';
+import * as server from '../../utils/serverAPI';
+import { useSocTotalPower } from '../../SOCTotalPowerProvider';
+import { useGlobalState } from '../../GlobalStateProvider';
+
+jest.mock('../../utils/serverAPI');
+jest.mock('../../SOCTotalPowerProvider', () => ({
+  useSocTotalPower: jest.fn(),
+}));
+jest.mock('../../GlobalStateProvider', () => ({
+  useGlobalState: jest.fn(),
+}));
+
+describe('ACPUTable Component', () => {
+  const mockDevice = 'mockDevice';
+  const mockNotify = jest.fn();
+  const mockUpdateTotalPower = jest.fn();
+  const mockUpdateGlobalState = jest.fn();
+  const mockAcpuNames = [{ text: 'ACPU1' }, { text: 'ACPU2' }];
+  const mockLoadActivity = [{ label: 'Low', value: 0 }, { label: 'High', value: 1 }];
+
+  beforeEach(() => {
+    useSocTotalPower.mockReturnValue({
+      updateTotalPower: mockUpdateTotalPower,
+    });
+    useGlobalState.mockReturnValue({
+      GetOptions: () => mockLoadActivity,
+      updateGlobalState: mockUpdateGlobalState,
+      acpuNames: mockAcpuNames,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders the Add button', () => {
+    render(<ACPUTable device={mockDevice} update={false} notify={mockNotify} />);
+
+    const addButton = screen.getByRole('button', { name: /add/i });
+    expect(addButton).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details - 

1. Created a new folder named tables_tests inside the tests directory to hold test files for the components table.
2. Added an initial Jest test file for APCUTable.js to ensure the basic functionality of the component is covered.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [x] Frontend: <Specify frontend components>Tables_Tests > APCUTable.test.js
> - [ ] Backend: <Specify backend components>
> - [ ] Library: <Specify the library name, e.g. npm packages>
> - [ ] Plug-in: <Specify the plugin name, e.g. Webpack, jtest>
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continuous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break backward-compatibility. If so, please list who may be influenced.
