### PR TITLE
Allow loading device without power data config

### DIFF
--- a/backend/submodule/rs_device.py
+++ b/backend/submodule/rs_device.py
@@ -236,6 +236,10 @@ class RsDevice:
         # soc peripherals module
         self.resources.register_module(ModuleType.SOC_PERIPHERALS, Peripheral_SubModule(self.resources))
 
+        # skip compute output power and exit function if no power data available
+        if not self.resources.powercfg.is_loaded():
+            return
+
         # perform initial calculation
         self.compute_output_power()
 

--- a/tests/test_rs_power_config.py
+++ b/tests/test_rs_power_config.py
@@ -17,50 +17,62 @@ from submodule.rs_power_config import (
     PowerConfigPolynomialNotFoundException
 )
 
+def test_not_loaded():
+    pwrcfg = RsPowerConfig()
+    assert False == pwrcfg.is_loaded()
+
 def test_invalid_power_config_filepath():
     with pytest.raises(PowerConfigFileNotFoundException):
-        RsPowerConfig(filepath='abc.json')
+        RsPowerConfig().load('abc.json')
 
 def test_invalid_json_content():
     with pytest.raises(PowerConfigParsingException):
-        RsPowerConfig(filepath='tests/data/invalid_power_config.json')
+        RsPowerConfig().load('tests/data/invalid_power_config.json')
 
 def test_invalid_json_ref():
     with pytest.raises(PowerConfigParsingException):
-        RsPowerConfig(filepath='tests/data/invalid_json_ref_power_config.json')
+        RsPowerConfig().load('tests/data/invalid_json_ref_power_config.json')
 
 def test_invalid_power_config_schema():
     with pytest.raises(PowerConfigSchemaValidationException):
-        RsPowerConfig(filepath='tests/data/invalid_schema_power_config.json')
+        RsPowerConfig().load('tests/data/invalid_schema_power_config.json')
 
 def test_get_coeff_with_not_exist_component():
-    pwrcfg = RsPowerConfig(filepath='tests/data/power_config.json')
+    pwrcfg = RsPowerConfig()
+    pwrcfg.load('tests/data/power_config.json')
     with pytest.raises(PowerConfigComponentNotFoundException):
         pwrcfg.get_coeff(ElementType.FABRIC_LE, "TEST1")
 
 def test_get_coeff_with_not_exist_coeff():
-    pwrcfg = RsPowerConfig(filepath='tests/data/power_config.json')
+    pwrcfg = RsPowerConfig()
+    pwrcfg.load('tests/data/power_config.json')
     with pytest.raises(PowerConfigCoeffNotFoundException):
         pwrcfg.get_coeff(ElementType.DSP, "ABC")
 
 def test_get_coeff():
-    pwrcfg = RsPowerConfig(filepath='tests/data/power_config.json')
+    pwrcfg = RsPowerConfig()
+    pwrcfg.load('tests/data/power_config.json')
     assert 0.1234 == pwrcfg.get_coeff(ElementType.DSP, "TEST1")
 
 def test_get_polynomial_coeff_with_not_exist_component():
-    pwrcfg = RsPowerConfig(filepath='tests/data/power_config.json')
+    pwrcfg = RsPowerConfig()
+    pwrcfg.load('tests/data/power_config.json')
     with pytest.raises(PowerConfigStaticComponentNotFoundException):
         pwrcfg.get_polynomial_coeff(ElementType.NOC, ScenarioType.TYPICAL)
 
 def test_get_polynomial_coeff_with_not_exist_scenario():
-    pwrcfg = RsPowerConfig(filepath='tests/data/power_config.json')
+    pwrcfg = RsPowerConfig()
+    pwrcfg.load('tests/data/power_config.json')
     with pytest.raises(PowerConfigPolynomialNotFoundException):
         pwrcfg.get_polynomial_coeff(ElementType.CLB, ScenarioType.WORSE)
 
 def test_get_polynomial_coeff():
-    pwrcfg = RsPowerConfig(filepath='tests/data/power_config.json')
+    pwrcfg = RsPowerConfig()
+    result = pwrcfg.load('tests/data/power_config.json')
     polynomials = pwrcfg.get_polynomial_coeff(ElementType.CLB, ScenarioType.TYPICAL)
     assert 1 == len(polynomials)
+    assert True == result
+    assert True == pwrcfg.is_loaded()
     assert 5 == polynomials[0].length
     assert 1.25 == polynomials[0].factor
     assert [0.1, 0.2, 0.3, 0.4, 0.5] == polynomials[0].coeffs


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [x] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> Changes:
> 1. Allow devices without power_data config in device.xml to be loaded in RPE
> 2. Do not raise exception if a device has not power_data config.
> 3. Do not exit backend process when a device has not power_data config
> 4. Allow RPE to run even there are devices without power_data config.

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Frontend: <Specify frontend components>
> - [x] Backend: DeviceManager, PowerCfg modules
> - [ ] Library: <Specify the library name, e.g. npm packages>
> - [ ] Plug-in: <Specify the plugin name, e.g. Webpack, jtest>
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continuous Integration (CI) scripts